### PR TITLE
add field sort to 'templating'

### DIFF
--- a/board.go
+++ b/board.go
@@ -93,6 +93,7 @@ type (
 		Current     Current  `json:"current"`
 		Label       string   `json:"label"`
 		Hide        uint8    `json:"hide"`
+		Sort        int      `json:"sort"`
 	}
 	// for templateVar
 	Option struct {


### PR DESCRIPTION
Good Evening

I am using the sdk to backup/restore/synchronize grafana dashboards. I noticed that the sorting field in the templates section is missing which should be fixed by this pull request.

Many thanks in advance
Kind regards

Raffael