### PR TITLE
Add support for Panel Description

### DIFF
--- a/panel.go
+++ b/panel.go
@@ -123,6 +123,7 @@ type (
 		DashLength  *uint       `json:"dashLength,omitempty"`
 		Dashes      *bool       `json:"dashes,omitempty"`
 		Decimals    *uint       `json:"decimals,omitempty"`
+		Description *string     `json:"description",omitempty`
 		Fill        int         `json:"fill"`
 		//		Grid        grid        `json:"grid"` obsoleted in 4.1 by xaxis and yaxis
 

--- a/panel.go
+++ b/panel.go
@@ -123,7 +123,7 @@ type (
 		DashLength  *uint       `json:"dashLength,omitempty"`
 		Dashes      *bool       `json:"dashes,omitempty"`
 		Decimals    *uint       `json:"decimals,omitempty"`
-		Description *string     `json:"description",omitempty`
+		Description *string     `json:"description,omitempty"`
 		Fill        int         `json:"fill"`
 		//		Grid        grid        `json:"grid"` obsoleted in 4.1 by xaxis and yaxis
 


### PR DESCRIPTION
This allows a Panel to add [a description](https://grafana.com/docs/features/panels/graph/#info) which can be seen by hovering in the upper left of the dashboard.