### PR TITLE
Read grafana response

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,13 @@ with Grafana then client SDK for Go will be uniquely useful.
 		Expr:       "sample request 1"}
 	graph.AddTarget(&target)
 	row1.Add(graph)
-	c := sdk.NewClient("http://grafana.host", "grafana-api-key", sdk.DefaultHTTPClient)	
-	if err = c.SetDashboard(board, false); err != nil {
+	c := sdk.NewClient("http://grafana.host", "grafana-api-key", sdk.DefaultHTTPClient)
+    response, err := c.SetDashboard(board, false)
+	err != nil {
 		fmt.Printf("error on uploading dashboard %s", board.Title)
-	}
+    } else {
+        fmt.Printf("dashboard URL: %v", *resp.URL)
+    }
 ```	
 
 The library includes several demo apps for showing API usage:

--- a/README.md
+++ b/README.md
@@ -64,12 +64,13 @@ with Grafana then client SDK for Go will be uniquely useful.
 		Expr:       "sample request 1"}
 	graph.AddTarget(&target)
 	row1.Add(graph)
-	c := sdk.NewClient("http://grafana.host", "grafana-api-key", sdk.DefaultHTTPClient)
+    grafanaURL := "http://grafana.host"
+	c := sdk.NewClient(grafanaURL, "grafana-api-key", sdk.DefaultHTTPClient)
     response, err := c.SetDashboard(board, false)
 	err != nil {
 		fmt.Printf("error on uploading dashboard %s", board.Title)
     } else {
-        fmt.Printf("dashboard URL: %v", *resp.URL)
+        fmt.Printf("dashboard URL: %v", grafanaURL+*resp.URL)
     }
 ```	
 

--- a/cmd/import-dashboards-raw/main.go
+++ b/cmd/import-dashboards-raw/main.go
@@ -65,5 +65,6 @@ func main() {
 				log.Printf("error on importing dashboard from %s", file.Name())
 				continue
 			}
+		}
 	}
 }

--- a/cmd/import-dashboards-raw/main.go
+++ b/cmd/import-dashboards-raw/main.go
@@ -60,10 +60,10 @@ func main() {
 				log.Println(err)
 				continue
 			}
-			if err = c.SetRawDashboard(rawBoard); err != nil {
+			_, err := c.SetRawDashboard(rawBoard)
+			if err != nil {
 				log.Printf("error on importing dashboard from %s", file.Name())
 				continue
 			}
-		}
 	}
 }

--- a/cmd/import-dashboards/main.go
+++ b/cmd/import-dashboards/main.go
@@ -65,7 +65,8 @@ func main() {
 				continue
 			}
 			c.DeleteDashboard(board.UpdateSlug())
-			if err = c.SetDashboard(board, false); err != nil {
+			_, err := c.SetDashboard(board, false)
+			if err != nil {
 				log.Printf("error on importing dashboard %s", board.Title)
 				continue
 			}

--- a/rest-request.go
+++ b/rest-request.go
@@ -49,6 +49,8 @@ type StatusMessage struct {
 	Slug    *string `json:"slug"`
 	Version *int    `json:"version"`
 	Status  *string `json:"resp"`
+	UID     *string `json:"uid"`
+	URL     *string `json:"url"`
 }
 
 // NewClient initializes client for interacting with an instance of Grafana server;


### PR DESCRIPTION
The answer to the successful creation of the dashboard is not ignored.
Fields added to the StatusMessage structure: UID and URL

I needed these changes because my microservice should return links to automatically generated dashboards.