### PR TITLE
Add support for /api/admin/users/:id/permissions endpoint

### DIFF
--- a/rest-admin.go
+++ b/rest-admin.go
@@ -26,6 +26,25 @@ func (r *Client) CreateUser(user User) (StatusMessage, error) {
 	return resp, nil
 }
 
+// UpdateUserPermissions updates the permissions of a global user
+// Only work with Basic Authentication
+// It reflects PUT /api/admin/users/:userId/permissions
+func (r *Client) UpdateUserPermissions(permissions UserPermissions, uid uint) (StatusMessage, error) {
+	var (
+		raw   []byte
+		reply StatusMessage
+		err   error
+	)
+	if raw, err = json.Marshal(permissions); err != nil {
+		return StatusMessage{}, err
+	}
+	if raw, _, err = r.put(fmt.Sprintf("api/admin/users/%d/permissions", uid), nil, raw); err != nil {
+		return StatusMessage{}, err
+	}
+	err = json.Unmarshal(raw, &reply)
+	return reply, err
+}
+
 func (r *Client) SwitchUserContext(uid uint, oid uint) (StatusMessage, error) {
 	var (
 		raw  []byte

--- a/user.go
+++ b/user.go
@@ -34,6 +34,10 @@ type UserRole struct {
 	Role         string `json:"role"`
 }
 
+type UserPermissions struct {
+	IsGrafanaAdmin bool `json:"isGrafanaAdmin"`
+}
+
 type PageUsers struct {
 	TotalCount int    `json:"totalCount"`
 	Users      []User `json:"users"`


### PR DESCRIPTION
New function will allow to update permissions (i.e. making the user an administrator) of an existing global user.