### PR TITLE
Allow to update organization preferences

### DIFF
--- a/preferences.go
+++ b/preferences.go
@@ -1,0 +1,25 @@
+package sdk
+
+/*
+   Copyright 2016-2017 Alexander I.Grafov <grafov@gmail.com>
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+   ॐ तारे तुत्तारे तुरे स्व
+*/
+
+type Preferences struct {
+	Theme           string `json:"theme,omitempty"`
+	HomeDashboardId uint   `json:"homeDashboardId,omitempty"`
+	Timezone        string `json:"timezone,omitempty"`
+}

--- a/rest-org.go
+++ b/rest-org.go
@@ -325,3 +325,23 @@ func (r *Client) DeleteOrgUser(oid, uid uint) (StatusMessage, error) {
 	err = json.Unmarshal(raw, &reply)
 	return reply, err
 }
+
+// UpdateActualOrgPreferences updates preferences of the actual organization.
+// It reflects DELETE /api/org/preferences API call.
+func (r *Client) UpdateActualOrgPreferences(prefs Preferences) (StatusMessage, error) {
+	var (
+		raw  []byte
+		resp StatusMessage
+		err  error
+	)
+	if raw, err = json.Marshal(prefs); err != nil {
+		return StatusMessage{}, err
+	}
+	if raw, _, err = r.put("api/org/preferences/", nil, raw); err != nil {
+		return StatusMessage{}, err
+	}
+	if err = json.Unmarshal(raw, &resp); err != nil {
+		return StatusMessage{}, err
+	}
+	return resp, nil
+}


### PR DESCRIPTION
Utilizes [`PUT /api/org/preferences` endpoint](https://grafana.com/docs/http_api/preferences/#update-current-org-prefs) to allow updating organization preferences.