### PR TITLE
Update and unify comments for REST functions

### DIFF
--- a/rest-admin.go
+++ b/rest-admin.go
@@ -6,8 +6,8 @@ import (
 )
 
 // CreateUser creates a new global user
-// Only work with Basic Authentication
-// It reflects POST /api/admin/users
+// Requires basic authentication and that the authenticated user is a Grafana Admin
+// It reflects POST /api/admin/users API call
 func (r *Client) CreateUser(user User) (StatusMessage, error) {
 	var (
 		raw  []byte
@@ -27,8 +27,8 @@ func (r *Client) CreateUser(user User) (StatusMessage, error) {
 }
 
 // UpdateUserPermissions updates the permissions of a global user
-// Only work with Basic Authentication
-// It reflects PUT /api/admin/users/:userId/permissions
+// Requires basic authentication and that the authenticated user is a Grafana Admin
+// It reflects PUT /api/admin/users/:userId/password API call
 func (r *Client) UpdateUserPermissions(permissions UserPermissions, uid uint) (StatusMessage, error) {
 	var (
 		raw   []byte
@@ -45,6 +45,9 @@ func (r *Client) UpdateUserPermissions(permissions UserPermissions, uid uint) (S
 	return reply, err
 }
 
+// SwitchUserContext switches user context to the given organization
+// Requires basic authentication and that the authenticated user is a Grafana Admin
+// It reflects POST /api/users/:userId/using/:organizationId API call
 func (r *Client) SwitchUserContext(uid uint, oid uint) (StatusMessage, error) {
 	var (
 		raw  []byte

--- a/rest-admin.go
+++ b/rest-admin.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 )
 
-// CreateUser creates a new global user
-// Requires basic authentication and that the authenticated user is a Grafana Admin
-// It reflects POST /api/admin/users API call
+// CreateUser creates a new global user.
+// Requires basic authentication and that the authenticated user is a Grafana Admin.
+// It reflects POST /api/admin/users API call.
 func (r *Client) CreateUser(user User) (StatusMessage, error) {
 	var (
 		raw  []byte
@@ -26,9 +26,9 @@ func (r *Client) CreateUser(user User) (StatusMessage, error) {
 	return resp, nil
 }
 
-// UpdateUserPermissions updates the permissions of a global user
-// Requires basic authentication and that the authenticated user is a Grafana Admin
-// It reflects PUT /api/admin/users/:userId/password API call
+// UpdateUserPermissions updates the permissions of a global user.
+// Requires basic authentication and that the authenticated user is a Grafana Admin.
+// It reflects PUT /api/admin/users/:userId/password API call.
 func (r *Client) UpdateUserPermissions(permissions UserPermissions, uid uint) (StatusMessage, error) {
 	var (
 		raw   []byte
@@ -45,9 +45,9 @@ func (r *Client) UpdateUserPermissions(permissions UserPermissions, uid uint) (S
 	return reply, err
 }
 
-// SwitchUserContext switches user context to the given organization
-// Requires basic authentication and that the authenticated user is a Grafana Admin
-// It reflects POST /api/users/:userId/using/:organizationId API call
+// SwitchUserContext switches user context to the given organization.
+// Requires basic authentication and that the authenticated user is a Grafana Admin.
+// It reflects POST /api/users/:userId/using/:organizationId API call.
 func (r *Client) SwitchUserContext(uid uint, oid uint) (StatusMessage, error) {
 	var (
 		raw  []byte

--- a/rest-admin.go
+++ b/rest-admin.go
@@ -7,7 +7,7 @@ import (
 
 // CreateUser creates a new global user.
 // Requires basic authentication and that the authenticated user is a Grafana Admin.
-// It reflects POST /api/admin/users API call.
+// Reflects POST /api/admin/users API call.
 func (r *Client) CreateUser(user User) (StatusMessage, error) {
 	var (
 		raw  []byte
@@ -28,7 +28,7 @@ func (r *Client) CreateUser(user User) (StatusMessage, error) {
 
 // UpdateUserPermissions updates the permissions of a global user.
 // Requires basic authentication and that the authenticated user is a Grafana Admin.
-// It reflects PUT /api/admin/users/:userId/password API call.
+// Reflects PUT /api/admin/users/:userId/password API call.
 func (r *Client) UpdateUserPermissions(permissions UserPermissions, uid uint) (StatusMessage, error) {
 	var (
 		raw   []byte
@@ -47,7 +47,7 @@ func (r *Client) UpdateUserPermissions(permissions UserPermissions, uid uint) (S
 
 // SwitchUserContext switches user context to the given organization.
 // Requires basic authentication and that the authenticated user is a Grafana Admin.
-// It reflects POST /api/users/:userId/using/:organizationId API call.
+// Reflects POST /api/users/:userId/using/:organizationId API call.
 func (r *Client) SwitchUserContext(uid uint, oid uint) (StatusMessage, error) {
 	var (
 		raw  []byte

--- a/rest-dashboard.go
+++ b/rest-dashboard.go
@@ -51,7 +51,7 @@ type BoardProperties struct {
 // a database assumed. Database dashboards may have "db/" prefix or may have not, it will
 // be appended automatically.
 //
-// It reflects GET /api/dashboards/db/:slug API call
+// It reflects GET /api/dashboards/db/:slug API call.
 func (r *Client) GetDashboard(slug string) (Board, BoardProperties, error) {
 	var (
 		raw    []byte
@@ -88,7 +88,7 @@ func (r *Client) GetDashboard(slug string) (Board, BoardProperties, error) {
 // a database assumed. Database dashboards may have "db/" prefix or may have not, it will
 // be appended automatically.
 //
-// It reflects GET /api/dashboards/db/:slug API call
+// It reflects GET /api/dashboards/db/:slug API call.
 func (r *Client) GetRawDashboard(slug string) ([]byte, BoardProperties, error) {
 	var (
 		raw    []byte
@@ -127,7 +127,7 @@ type FoundBoard struct {
 // SearchDashboards search dashboards by substring of their title. It allows restrict the result set with
 // only starred dashboards and only for tags (logical OR applied to multiple tags).
 //
-// It reflects GET /api/search API call
+// It reflects GET /api/search API call.
 func (r *Client) SearchDashboards(query string, starred bool, tags ...string) ([]FoundBoard, error) {
 	var (
 		raw    []byte
@@ -163,7 +163,7 @@ func (r *Client) SearchDashboards(query string, starred bool, tags ...string) ([
 // Grafana only can create or update a dashboard in a database. File dashboards
 // may be only loaded with HTTP API but not created or updated.
 //
-// It reflects POST /api/dashboards/db API call
+// It reflects POST /api/dashboards/db API call.
 func (r *Client) SetDashboard(board Board, overwrite bool) (StatusMessage, error) {
 	var (
 		isBoardFromDB bool
@@ -204,7 +204,7 @@ func (r *Client) SetDashboard(board Board, overwrite bool) (StatusMessage, error
 // Grafana only can create or update a dashboard in a database. File dashboards
 // may be only loaded with HTTP API but not created or updated.
 //
-// It reflects POST /api/dashboards/db API call
+// It reflects POST /api/dashboards/db API call.
 func (r *Client) SetRawDashboard(raw []byte) (StatusMessage, error) {
 	var (
 		rawResp []byte
@@ -239,7 +239,7 @@ func (r *Client) SetRawDashboard(raw []byte) (StatusMessage, error) {
 // Grafana only can delete a dashboard in a database. File dashboards
 // may be only loaded with HTTP API but not deteled.
 //
-// It reflects DELETE /api/dashboards/db/:slug API call
+// It reflects DELETE /api/dashboards/db/:slug API call.
 func (r *Client) DeleteDashboard(slug string) (StatusMessage, error) {
 	var (
 		isBoardFromDB bool

--- a/rest-dashboard.go
+++ b/rest-dashboard.go
@@ -50,6 +50,8 @@ type BoardProperties struct {
 // For dashboards from a filesystem set "file/" prefix for slug. By default dashboards from
 // a database assumed. Database dashboards may have "db/" prefix or may have not, it will
 // be appended automatically.
+//
+// It reflects GET /api/dashboards/db/:slug API call
 func (r *Client) GetDashboard(slug string) (Board, BoardProperties, error) {
 	var (
 		raw    []byte
@@ -85,6 +87,8 @@ func (r *Client) GetDashboard(slug string) (Board, BoardProperties, error) {
 // For dashboards from a filesystem set "file/" prefix for slug. By default dashboards from
 // a database assumed. Database dashboards may have "db/" prefix or may have not, it will
 // be appended automatically.
+//
+// It reflects GET /api/dashboards/db/:slug API call
 func (r *Client) GetRawDashboard(slug string) ([]byte, BoardProperties, error) {
 	var (
 		raw    []byte
@@ -122,6 +126,8 @@ type FoundBoard struct {
 
 // SearchDashboards search dashboards by substring of their title. It allows restrict the result set with
 // only starred dashboards and only for tags (logical OR applied to multiple tags).
+//
+// It reflects GET /api/search API call
 func (r *Client) SearchDashboards(query string, starred bool, tags ...string) ([]FoundBoard, error) {
 	var (
 		raw    []byte
@@ -156,6 +162,8 @@ func (r *Client) SearchDashboards(query string, starred bool, tags ...string) ([
 // newer version or with same dashboard title.
 // Grafana only can create or update a dashboard in a database. File dashboards
 // may be only loaded with HTTP API but not created or updated.
+//
+// It reflects POST /api/dashboards/db API call
 func (r *Client) SetDashboard(board Board, overwrite bool) (StatusMessage, error) {
 	var (
 		isBoardFromDB bool
@@ -195,6 +203,8 @@ func (r *Client) SetDashboard(board Board, overwrite bool) (StatusMessage, error
 // Contrary to SetDashboard() it accepts raw JSON instead of Board structure.
 // Grafana only can create or update a dashboard in a database. File dashboards
 // may be only loaded with HTTP API but not created or updated.
+//
+// It reflects POST /api/dashboards/db API call
 func (r *Client) SetRawDashboard(raw []byte) (StatusMessage, error) {
 	var (
 		rawResp []byte
@@ -228,6 +238,8 @@ func (r *Client) SetRawDashboard(raw []byte) (StatusMessage, error) {
 // DeleteDashboard deletes dashboard that selected by slug string.
 // Grafana only can delete a dashboard in a database. File dashboards
 // may be only loaded with HTTP API but not deteled.
+//
+// It reflects DELETE /api/dashboards/db/:slug API call
 func (r *Client) DeleteDashboard(slug string) (StatusMessage, error) {
 	var (
 		isBoardFromDB bool

--- a/rest-dashboard.go
+++ b/rest-dashboard.go
@@ -51,7 +51,7 @@ type BoardProperties struct {
 // a database assumed. Database dashboards may have "db/" prefix or may have not, it will
 // be appended automatically.
 //
-// It reflects GET /api/dashboards/db/:slug API call.
+// Reflects GET /api/dashboards/db/:slug API call.
 func (r *Client) GetDashboard(slug string) (Board, BoardProperties, error) {
 	var (
 		raw    []byte
@@ -88,7 +88,7 @@ func (r *Client) GetDashboard(slug string) (Board, BoardProperties, error) {
 // a database assumed. Database dashboards may have "db/" prefix or may have not, it will
 // be appended automatically.
 //
-// It reflects GET /api/dashboards/db/:slug API call.
+// Reflects GET /api/dashboards/db/:slug API call.
 func (r *Client) GetRawDashboard(slug string) ([]byte, BoardProperties, error) {
 	var (
 		raw    []byte
@@ -127,7 +127,7 @@ type FoundBoard struct {
 // SearchDashboards search dashboards by substring of their title. It allows restrict the result set with
 // only starred dashboards and only for tags (logical OR applied to multiple tags).
 //
-// It reflects GET /api/search API call.
+// Reflects GET /api/search API call.
 func (r *Client) SearchDashboards(query string, starred bool, tags ...string) ([]FoundBoard, error) {
 	var (
 		raw    []byte
@@ -163,7 +163,7 @@ func (r *Client) SearchDashboards(query string, starred bool, tags ...string) ([
 // Grafana only can create or update a dashboard in a database. File dashboards
 // may be only loaded with HTTP API but not created or updated.
 //
-// It reflects POST /api/dashboards/db API call.
+// Reflects POST /api/dashboards/db API call.
 func (r *Client) SetDashboard(board Board, overwrite bool) (StatusMessage, error) {
 	var (
 		isBoardFromDB bool
@@ -204,7 +204,7 @@ func (r *Client) SetDashboard(board Board, overwrite bool) (StatusMessage, error
 // Grafana only can create or update a dashboard in a database. File dashboards
 // may be only loaded with HTTP API but not created or updated.
 //
-// It reflects POST /api/dashboards/db API call.
+// Reflects POST /api/dashboards/db API call.
 func (r *Client) SetRawDashboard(raw []byte) (StatusMessage, error) {
 	var (
 		rawResp []byte
@@ -239,7 +239,7 @@ func (r *Client) SetRawDashboard(raw []byte) (StatusMessage, error) {
 // Grafana only can delete a dashboard in a database. File dashboards
 // may be only loaded with HTTP API but not deteled.
 //
-// It reflects DELETE /api/dashboards/db/:slug API call.
+// Reflects DELETE /api/dashboards/db/:slug API call.
 func (r *Client) DeleteDashboard(slug string) (StatusMessage, error) {
 	var (
 		isBoardFromDB bool

--- a/rest-datasource.go
+++ b/rest-datasource.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 )
 
-// GetAllDatasources loads all datasources.
+// GetAllDatasources gets all datasources.
 // It reflects GET /api/datasources API call.
 func (r *Client) GetAllDatasources() ([]Datasource, error) {
 	var (

--- a/rest-datasource.go
+++ b/rest-datasource.go
@@ -24,7 +24,7 @@ import (
 )
 
 // GetAllDatasources gets all datasources.
-// It reflects GET /api/datasources API call.
+// Reflects GET /api/datasources API call.
 func (r *Client) GetAllDatasources() ([]Datasource, error) {
 	var (
 		raw  []byte
@@ -43,7 +43,7 @@ func (r *Client) GetAllDatasources() ([]Datasource, error) {
 }
 
 // GetDatasource gets an datasource by ID.
-// It reflects GET /api/datasources/:datasourceId API call.
+// Reflects GET /api/datasources/:datasourceId API call.
 func (r *Client) GetDatasource(id uint) (Datasource, error) {
 	var (
 		raw  []byte
@@ -62,7 +62,7 @@ func (r *Client) GetDatasource(id uint) (Datasource, error) {
 }
 
 // GetDatasourceByName gets an datasource by Name.
-// It reflects GET /api/datasources/name/:datasourceName API call.
+// Reflects GET /api/datasources/name/:datasourceName API call.
 func (r *Client) GetDatasourceByName(name string) (Datasource, error) {
 	var (
 		raw  []byte
@@ -81,7 +81,7 @@ func (r *Client) GetDatasourceByName(name string) (Datasource, error) {
 }
 
 // CreateDatasource creates a new datasource.
-// It reflects POST /api/datasources API call.
+// Reflects POST /api/datasources API call.
 func (r *Client) CreateDatasource(ds Datasource) (StatusMessage, error) {
 	var (
 		raw  []byte
@@ -101,7 +101,7 @@ func (r *Client) CreateDatasource(ds Datasource) (StatusMessage, error) {
 }
 
 // UpdateDatasource updates a datasource from data passed in argument.
-// It reflects PUT /api/datasources/:datasourceId API call.
+// Reflects PUT /api/datasources/:datasourceId API call.
 func (r *Client) UpdateDatasource(ds Datasource) (StatusMessage, error) {
 	var (
 		raw  []byte
@@ -121,7 +121,7 @@ func (r *Client) UpdateDatasource(ds Datasource) (StatusMessage, error) {
 }
 
 // DeleteDatasource deletes an existing datasource by ID.
-// It reflects DELETE /api/datasources/:datasourceId API call.
+// Reflects DELETE /api/datasources/:datasourceId API call.
 func (r *Client) DeleteDatasource(id uint) (StatusMessage, error) {
 	var (
 		raw   []byte
@@ -136,7 +136,7 @@ func (r *Client) DeleteDatasource(id uint) (StatusMessage, error) {
 }
 
 // DeleteDatasourceByName deletes an existing datasource by Name.
-// It reflects DELETE /api/datasources/name/:datasourceName API call.
+// Reflects DELETE /api/datasources/name/:datasourceName API call.
 func (r *Client) DeleteDatasourceByName(name string) (StatusMessage, error) {
 	var (
 		raw   []byte
@@ -151,7 +151,7 @@ func (r *Client) DeleteDatasourceByName(name string) (StatusMessage, error) {
 }
 
 // GetDatasourceTypes gets all available plugins for the datasources.
-// It reflects GET /api/datasources/plugins API call.
+// Reflects GET /api/datasources/plugins API call.
 func (r *Client) GetDatasourceTypes() (map[string]DatasourceType, error) {
 	var (
 		raw     []byte

--- a/rest-org.go
+++ b/rest-org.go
@@ -48,7 +48,7 @@ func (r *Client) CreateOrg(org Org) (StatusMessage, error) {
 }
 
 // GetActualOrg gets current organization.
-// It reflects GET /api/orgs API call.
+// It reflects GET /api/org API call.
 func (r *Client) GetActualOrg() (Org, error) {
 	var (
 		raw  []byte

--- a/rest-org.go
+++ b/rest-org.go
@@ -27,8 +27,8 @@ import (
 	"net/http"
 )
 
-// CreateOrg creates a new organization
-// It reflects POST /api/orgs
+// CreateOrg creates a new organization.
+// It reflects POST /api/orgs API call.
 func (r *Client) CreateOrg(org Org) (StatusMessage, error) {
 	var (
 		raw  []byte
@@ -48,7 +48,7 @@ func (r *Client) CreateOrg(org Org) (StatusMessage, error) {
 }
 
 // GetActualOrg gets current organization.
-// It reflects GET /api/org API call.
+// It reflects GET /api/orgs API call.
 func (r *Client) GetActualOrg() (Org, error) {
 	var (
 		raw  []byte
@@ -70,8 +70,8 @@ func (r *Client) GetActualOrg() (Org, error) {
 	return org, err
 }
 
-// GetOrgById gets organization by organization Id
-// It reflects GET /api/orgs/:orgId
+// GetOrgById gets organization by organization Id.
+// It reflects GET /api/orgs/:orgId API call.
 func (r *Client) GetOrgById(oid uint) (Org, error) {
 	var (
 		raw  []byte
@@ -94,8 +94,8 @@ func (r *Client) GetOrgById(oid uint) (Org, error) {
 	return org, err
 }
 
-// GetOrgByOrgName gets organization by organization name
-// It reflects GET /api/orgs/name/:orgName
+// GetOrgByOrgName gets organization by organization name.
+// It reflects GET /api/orgs/name/:orgName API call.
 func (r *Client) GetOrgByOrgName(name string) (Org, error) {
 	var (
 		raw  []byte
@@ -138,8 +138,8 @@ func (r *Client) UpdateActualOrg(org Org) (StatusMessage, error) {
 	return resp, nil
 }
 
-//UpdateOrg updates the organization identified by oid.
-// It reflects PUT /api/orgs/:orgId
+// UpdateOrg updates the organization identified by oid.
+// It reflects PUT /api/orgs/:orgId API call.
 func (r *Client) UpdateOrg(org Org, oid uint) (StatusMessage, error) {
 	var (
 		raw  []byte
@@ -158,8 +158,8 @@ func (r *Client) UpdateOrg(org Org, oid uint) (StatusMessage, error) {
 	return resp, nil
 }
 
-// DeleteOrg deletes the organization identified by the organization id
-// Reflects DELETE /api/orgs/:orgId
+// DeleteOrg deletes the organization identified by the oid.
+// Reflects DELETE /api/orgs/:orgId API call.
 func (r *Client) DeleteOrg(oid uint) (StatusMessage, error) {
 	var (
 		raw  []byte
@@ -176,6 +176,7 @@ func (r *Client) DeleteOrg(oid uint) (StatusMessage, error) {
 }
 
 // GetActualOrgUsers get all users within the actual organisation.
+// Reflects GET /api/org/users API call.
 func (r *Client) GetActualOrgUsers() ([]OrgUser, error) {
 	var (
 		raw   []byte
@@ -197,8 +198,8 @@ func (r *Client) GetActualOrgUsers() ([]OrgUser, error) {
 	return users, err
 }
 
-// GetOrgUsers gets the users for the organization specified by organization id
-// Reflects GET /api/orgs/:orgId/users
+// GetOrgUsers gets the users for the organization specified by oid.
+// Reflects GET /api/orgs/:orgId/users API call.
 func (r *Client) GetOrgUsers(oid uint) ([]OrgUser, error) {
 	var (
 		raw   []byte
@@ -220,8 +221,8 @@ func (r *Client) GetOrgUsers(oid uint) ([]OrgUser, error) {
 	return users, err
 }
 
-// AddActualOrgUser creates a new organization
-// It reflects POST /api/org/users
+// AddActualOrgUser adds a global user to the current organization.
+// Reflects POST /api/org/users API call.
 func (r *Client) AddActualOrgUser(userRole UserRole) (StatusMessage, error) {
 	var (
 		raw  []byte
@@ -240,8 +241,8 @@ func (r *Client) AddActualOrgUser(userRole UserRole) (StatusMessage, error) {
 	return resp, nil
 }
 
-// UpdateUser updates the existing user
-// It reflects POST /api/org/users/:userId
+// UpdateUser updates the existing user.
+// Reflects POST /api/org/users/:userId API call.
 func (r *Client) UpdateActualOrgUser(user UserRole, uid uint) (StatusMessage, error) {
 	var (
 		raw  []byte
@@ -260,8 +261,8 @@ func (r *Client) UpdateActualOrgUser(user UserRole, uid uint) (StatusMessage, er
 	return resp, nil
 }
 
-// DeleteActualOrgUser delete user in actual organisation.
-// It reflects DELETE /api/org/users/:userId API call.
+// DeleteActualOrgUser delete user in actual organization.
+// Reflects DELETE /api/org/users/:userId API call.
 func (r *Client) DeleteActualOrgUser(uid uint) (StatusMessage, error) {
 	var (
 		raw   []byte
@@ -275,8 +276,8 @@ func (r *Client) DeleteActualOrgUser(uid uint) (StatusMessage, error) {
 	return reply, err
 }
 
-// AddUserToOrg add user to organization with id
-// It reflects POST /api/orgs/:orgId/users API call.
+// AddUserToOrg add user to organization with oid.
+// Reflects POST /api/orgs/:orgId/users API call.
 func (r *Client) AddOrgUser(user UserRole, oid uint) (StatusMessage, error) {
 	var (
 		raw   []byte
@@ -293,8 +294,8 @@ func (r *Client) AddOrgUser(user UserRole, oid uint) (StatusMessage, error) {
 	return reply, err
 }
 
-// UpdateOrgUser updates the user specified by uid within the organization specified by oid
-// It reflects PATCH /api/orgs/:orgId/users/:userId API call.
+// UpdateOrgUser updates the user specified by uid within the organization specified by oid.
+// Reflects PATCH /api/orgs/:orgId/users/:userId API call.
 func (r *Client) UpdateOrgUser(user UserRole, oid, uid uint) (StatusMessage, error) {
 	var (
 		raw   []byte
@@ -311,8 +312,8 @@ func (r *Client) UpdateOrgUser(user UserRole, oid, uid uint) (StatusMessage, err
 	return reply, err
 }
 
-// DeleteOrgUser deletes the user specified by uid within the organization specified by oid
-// It reflects DELETE /api/orgs/:orgId/users/:userId API call.
+// DeleteOrgUser deletes the user specified by uid within the organization specified by oid.
+// Reflects DELETE /api/orgs/:orgId/users/:userId API call.
 func (r *Client) DeleteOrgUser(oid, uid uint) (StatusMessage, error) {
 	var (
 		raw   []byte
@@ -327,7 +328,7 @@ func (r *Client) DeleteOrgUser(oid, uid uint) (StatusMessage, error) {
 }
 
 // UpdateActualOrgPreferences updates preferences of the actual organization.
-// It reflects DELETE /api/org/preferences API call.
+// Reflects PUT /api/org/preferences API call.
 func (r *Client) UpdateActualOrgPreferences(prefs Preferences) (StatusMessage, error) {
 	var (
 		raw  []byte

--- a/rest-user.go
+++ b/rest-user.go
@@ -26,6 +26,7 @@ import (
 )
 
 // GetActualUser gets an actual user.
+// Reflects GET /api/user API call.
 func (r *Client) GetActualUser() (User, error) {
 	var (
 		raw  []byte
@@ -48,6 +49,7 @@ func (r *Client) GetActualUser() (User, error) {
 }
 
 // GetUser gets an user by ID.
+// Reflects GET /api/users/:id API call.
 func (r *Client) GetUser(id uint) (User, error) {
 	var (
 		raw  []byte
@@ -70,6 +72,7 @@ func (r *Client) GetUser(id uint) (User, error) {
 }
 
 // GetAllUsers gets all users.
+// Reflects GET /api/users API call.
 func (r *Client) GetAllUsers() ([]User, error) {
 	var (
 		raw   []byte
@@ -91,12 +94,14 @@ func (r *Client) GetAllUsers() ([]User, error) {
 	return users, err
 }
 
-// SearchUsersWithPaging search users with paging
+// SearchUsersWithPaging search users with paging.
 // query optional.  query value is contained in one of the name, login or email fields. Query values with spaces need to be url encoded e.g. query=Jane%20Doe
 // perpage optional. default 1000
 // page optional. default 1
 // http://docs.grafana.org/http_api/user/#search-users
 // http://docs.grafana.org/http_api/user/#search-users-with-paging
+//
+// Reflects GET /api/users/search API call.
 func (r *Client) SearchUsersWithPaging(query *string, perpage, page *int) (PageUsers, error) {
 	var (
 		raw       []byte


### PR DESCRIPTION
Some REST functions were missing comments, while comments for others didn't include (or included incorrect) API endpoints. Trying to unify them.