### PR TITLE
Update README REST API realization status

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,18 +111,18 @@ datasources. State of support for misc API parts noted below.
 
 <!--- 
 #+ORGTBL: SEND status orgtbl-to-gfm
-| API                    | Status          |
-|------------------------+-----------------|
-| Authorization          | only API tokens |
-| Dashboards             | partially       |
-| Datasources            | +               |
-| Organization (current) | partially       |
-| Organizations          | -               |
-| Users                  | partially       |
-| User (actual)          | partially       |
-| Snapshots              | -               |
-| Frontend settings      | -               |
-| Admin                  | -               |
+| API                    | Status                    |
+|------------------------+---------------------------|
+| Authorization          | API tokens and Basic Auth |
+| Dashboards             | partially                 |
+| Datasources            | +                         |
+| Organization (current) | partially                 |
+| Organizations          | partially                 |
+| Users                  | partially                 |
+| User (actual)          | partially                 |
+| Snapshots              | -                         |
+| Frontend settings      | -                         |
+| Admin                  | partially                 |
 -->
 
 <!--- BEGIN RECEIVE ORGTBL status -->

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ with Grafana then client SDK for Go will be uniquely useful.
     } else {
         fmt.Printf("dashboard URL: %v", grafanaURL+*resp.URL)
     }
-```	
+```
 
 The library includes several demo apps for showing API usage:
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ implemented only create/update/delete operations for dashboards and
 datasources. State of support for misc API parts noted below.
 
 | API                    | Status                    |
-|------------------------+---------------------------|
+|------------------------|---------------------------|
 | Authorization          | API tokens and Basic Auth |
 | Dashboards             | partially                 |
 | Datasources            | +                         |

--- a/README.md
+++ b/README.md
@@ -109,8 +109,6 @@ Work on full API implementation still in progress. Currently
 implemented only create/update/delete operations for dashboards and
 datasources. State of support for misc API parts noted below.
 
-<!--- 
-#+ORGTBL: SEND status orgtbl-to-gfm
 | API                    | Status                    |
 |------------------------+---------------------------|
 | Authorization          | API tokens and Basic Auth |
@@ -123,22 +121,6 @@ datasources. State of support for misc API parts noted below.
 | Snapshots              | -                         |
 | Frontend settings      | -                         |
 | Admin                  | partially                 |
--->
-
-<!--- BEGIN RECEIVE ORGTBL status -->
-| API | Status |
-|---|---|
-| Authorization | only API tokens |
-| Dashboards | partially |
-| Datasources | + |
-| Organization (current) | partially |
-| Organizations | - |
-| Users | partially |
-| User (actual) | partially |
-| Snapshots | - |
-| Frontend settings | - |
-| Admin | - |
-<!--- END RECEIVE ORGTBL status -->
 
 ## Roadmap
 


### PR DESCRIPTION
It seems that REST API realization status in README file was a bit outdated, as organization and admin API endpoints are partially supported now. In addition, the SDK supports both API Tokens, as well as Basic Auth for the authorization.