### PR TITLE
Increase the limit of users returned

### DIFF
--- a/rest-user.go
+++ b/rest-user.go
@@ -80,7 +80,12 @@ func (r *Client) GetAllUsers() ([]User, error) {
 		code  int
 		err   error
 	)
-	if raw, code, err = r.get("api/users", nil); err != nil {
+	
+	params := url.Values{}
+	params.Set("perpage", "99999")
+	if raw, code, err = r.get("api/users", params); err != nil {
+		return users, err
+	}
 		return users, err
 	}
 	if code != 200 {

--- a/rest-user.go
+++ b/rest-user.go
@@ -86,8 +86,6 @@ func (r *Client) GetAllUsers() ([]User, error) {
 	if raw, code, err = r.get("api/users", params); err != nil {
 		return users, err
 	}
-		return users, err
-	}
 	if code != 200 {
 		return users, fmt.Errorf("HTTP error %d: returns %s", code, raw)
 	}

--- a/rest-user.go
+++ b/rest-user.go
@@ -80,7 +80,7 @@ func (r *Client) GetAllUsers() ([]User, error) {
 		code  int
 		err   error
 	)
-	
+
 	params := url.Values{}
 	params.Set("perpage", "99999")
 	if raw, code, err = r.get("api/users", params); err != nil {


### PR DESCRIPTION
As per documentation, `/api/users` returns only the first 1000 users. This means, that for Grafana instances that have more than 1000 users, this SDK function does not return all users.

One option could be introducing a parameter, for `GetAllUsers()`, but that would be a breaking change for all existing users. As an alternative, I suggest setting the limit to a very high number (`99999`, in this case). This would avoid a breaking change and would make `GetAllUsers()` to work as expected (since the name implies it returns ALL users).