### PR TITLE
Remove build flag from rest-org.go

### DIFF
--- a/rest-org.go
+++ b/rest-org.go
@@ -1,5 +1,3 @@
-// +build draft
-
 package sdk
 
 /*

--- a/rest-org.go
+++ b/rest-org.go
@@ -275,7 +275,7 @@ func (r *Client) UpdateActualOrgUser(user UserRole, uid uint) (StatusMessage, er
 	if raw, err = json.Marshal(user); err != nil {
 		return StatusMessage{}, err
 	}
-	if raw, _, err = r.post(fmt.Sprintf("api/org/users/%s", uid), nil, raw); err != nil {
+	if raw, _, err = r.post(fmt.Sprintf("api/org/users/%d", uid), nil, raw); err != nil {	
 		return StatusMessage{}, err
 	}
 	if err = json.Unmarshal(raw, &resp); err != nil {


### PR DESCRIPTION
I don't know why but this file is ignored by the go compiler because of this // +build draft comment line.

Removing this file fixes the issue. 