### PR TITLE
datasource: add secureJsonData

### DIFF
--- a/datasource.go
+++ b/datasource.go
@@ -36,6 +36,7 @@ type Datasource struct {
 	BasicAuthPassword *string     `json:"basicAuthPassword,omitempty"`
 	IsDefault         bool        `json:"isDefault"`
 	JSONData          interface{} `json:"jsonData"`
+	SecureJSONData    interface{} `json:"secureJsonData"`
 }
 
 // Datasource type as described in


### PR DESCRIPTION
Add a new member to the `Datasource` struct called SecureJSONData which
gets passed as `secureJsonData`. This is needed because certain features
are only available via that e.g. passing custom header values.

Signed-off-by: Giedrius Statkevičius <giedriuswork@gmail.com>