### PR TITLE
Add alertnotification API support

### DIFF
--- a/alertnotification.go
+++ b/alertnotification.go
@@ -1,0 +1,31 @@
+package sdk
+
+/*
+   Copyright 2016-2020 The Grafana SDK authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+	   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// AlertNotification as described in the doc
+// https://grafana.com/docs/grafana/latest/http_api/alerting_notification_channels/
+type AlertNotification struct {
+	ID                    int64       `json:"id,omitempty"`
+	Name                  string      `json:"name"`
+	Type                  string      `json:"type"`
+	IsDefault             bool        `json:"isDefault"`
+	DisableResolveMessage bool        `json:"disableResolveMessage"`
+	SendReminder          bool        `json:"sendReminder"`
+	Frequency             string      `json:"frequency"`
+	Settings              interface{} `json:"settings"`
+	UID                   string      `json:"uid,omitempty"`
+}

--- a/datasource.go
+++ b/datasource.go
@@ -36,6 +36,7 @@ type Datasource struct {
 	BasicAuthPassword *string     `json:"basicAuthPassword,omitempty"`
 	IsDefault         bool        `json:"isDefault"`
 	JSONData          interface{} `json:"jsonData"`
+	SecureJSONData    interface{} `json:"secureJsonData"`
 }
 
 // Datasource type as described in

--- a/panel.go
+++ b/panel.go
@@ -105,10 +105,6 @@ type (
 		} `json:"reducer,omitempty"`
 		Type string `json:"type,omitempty"`
 	}
-	AlertNotification struct {
-		ID  int    `json:"id,omitempty"`
-		UID string `json:"uid,omitempty"`
-	}
 	Alert struct {
 		Conditions          []AlertCondition    `json:"conditions,omitempty"`
 		ExecutionErrorState string              `json:"executionErrorState,omitempty"`

--- a/rest-alertnotification.go
+++ b/rest-alertnotification.go
@@ -1,0 +1,177 @@
+package sdk
+
+/*
+   Copyright 2016-2020 The Grafana SDK authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+	   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// GetAllAlertNotifications gets all alert notification channels.
+// Reflects GET /api/alert-notifications API call.
+func (c *Client) GetAllAlertNotifications() ([]AlertNotification, error) {
+	var (
+		raw  []byte
+		an   []AlertNotification
+		code int
+		err  error
+	)
+	if raw, code, err = c.get("api/alert-notifications", nil); err != nil {
+		return nil, err
+	}
+	if code != 200 {
+		return nil, fmt.Errorf("HTTP error %d: returns %s", code, raw)
+	}
+	err = json.Unmarshal(raw, &an)
+	return an, err
+}
+
+// GetAlertNotificationUID gets the alert notification channel which has the specified uid.
+// Reflects GET /api/alert-notifications/uid/:uid API call.
+func (c *Client) GetAlertNotificationUID(uid string) (AlertNotification, error) {
+	var (
+		raw  []byte
+		an   AlertNotification
+		code int
+		err  error
+	)
+	if raw, code, err = c.get(fmt.Sprintf("api/alert-notifications/uid/%s", uid), nil); err != nil {
+		return an, err
+	}
+	if code != 200 {
+		return an, fmt.Errorf("HTTP error %d: returns %s", code, raw)
+	}
+	err = json.Unmarshal(raw, &an)
+	return an, err
+}
+
+// GetAlertNotificationID gets the alert notification channel which has the specified id.
+// Reflects GET /api/alert-notifications/:id API call.
+func (c *Client) GetAlertNotificationID(id uint) (AlertNotification, error) {
+	var (
+		raw  []byte
+		an   AlertNotification
+		code int
+		err  error
+	)
+	if raw, code, err = c.get(fmt.Sprintf("api/alert-notifications/%d", id), nil); err != nil {
+		return an, err
+	}
+	if code != 200 {
+		return an, fmt.Errorf("HTTP error %d: returns %s", code, raw)
+	}
+	err = json.Unmarshal(raw, &an)
+	return an, err
+}
+
+// CreateAlertNotification creates a new alert notification channel.
+// Reflects POST /api/alert-notifications API call.
+func (c *Client) CreateAlertNotification(an AlertNotification) (int64, error) {
+	var (
+		raw  []byte
+		code int
+		err  error
+	)
+	if raw, err = json.Marshal(an); err != nil {
+		return -1, err
+	}
+	if raw, code, err = c.post(fmt.Sprintf("api/alert-notifications"), nil, raw); err != nil {
+		return -1, err
+	}
+	if code != 200 {
+		return -1, fmt.Errorf("HTTP error %d: returns %s", code, raw)
+	}
+	result := struct {
+		ID int64 `json:"id"`
+	}{}
+	err = json.Unmarshal(raw, &result)
+	return result.ID, err
+}
+
+// UpdateAlertNotificationUID updates the specified alert notification channel.
+// Reflects PUT /api/alert-notifications/uid/:uid API call.
+func (c *Client) UpdateAlertNotificationUID(an AlertNotification, uid string) error {
+	var (
+		raw  []byte
+		code int
+		err  error
+	)
+	if raw, err = json.Marshal(an); err != nil {
+		return err
+	}
+	if raw, code, err = c.put(fmt.Sprintf("api/alert-notifications/uid/%s", uid), nil, raw); err != nil {
+		return err
+	}
+	if code != 200 {
+		return fmt.Errorf("HTTP error %d: returns %s", code, raw)
+	}
+	return nil
+}
+
+// UpdateAlertNotificationID updates the specified alert notification channel.
+// Reflects PUT /api/alert-notifications/:id API call.
+func (c *Client) UpdateAlertNotificationID(an AlertNotification, id uint) error {
+	var (
+		raw  []byte
+		code int
+		err  error
+	)
+	if raw, err = json.Marshal(an); err != nil {
+		return err
+	}
+	if raw, code, err = c.put(fmt.Sprintf("api/alert-notifications/id/%d", id), nil, raw); err != nil {
+		return err
+	}
+	if code != 200 {
+		return fmt.Errorf("HTTP error %d: returns %s", code, raw)
+	}
+	return nil
+}
+
+// DeleteAlertNotificationUID deletes the specified alert notification channel.
+// Reflects DELETE /api/alert-notifications/uid/:uid API call.
+func (c *Client) DeleteAlertNotificationUID(uid string) error {
+	var (
+		raw  []byte
+		code int
+		err  error
+	)
+	if raw, code, err = c.delete(fmt.Sprintf("api/alert-notifications/uid/%s", uid)); err != nil {
+		return err
+	}
+	if code != 200 {
+		return fmt.Errorf("HTTP error %d: returns %s", code, raw)
+	}
+	return nil
+}
+
+// DeleteAlertNotificationID deletes the specified alert notification channel.
+// Reflects DELETE /api/alert-notifications/:id API call.
+func (c *Client) DeleteAlertNotificationID(id uint) error {
+	var (
+		raw  []byte
+		code int
+		err  error
+	)
+	if raw, code, err = c.delete(fmt.Sprintf("api/alert-notifications/%d", id)); err != nil {
+		return err
+	}
+	if code != 200 {
+		return fmt.Errorf("HTTP error %d: returns %s", code, raw)
+	}
+	return nil
+}

--- a/rest-alertnotification.go
+++ b/rest-alertnotification.go
@@ -133,7 +133,7 @@ func (c *Client) UpdateAlertNotificationID(an AlertNotification, id uint) error 
 	if raw, err = json.Marshal(an); err != nil {
 		return err
 	}
-	if raw, code, err = c.put(fmt.Sprintf("api/alert-notifications/id/%d", id), nil, raw); err != nil {
+	if raw, code, err = c.put(fmt.Sprintf("api/alert-notifications/%d", id), nil, raw); err != nil {
 		return err
 	}
 	if code != 200 {


### PR DESCRIPTION
Add `alertnotification.go` which contains the struct definition of an
`alertnotification`. Add `rest-alertnotification.go` which contains the
API wrappers. Edit `panel.go` to remove the old definition of an
alertnotification since it is not complete and it belongs in its own
file.

Tested with internal integration tests with Grafana 6.5.2.

PR is based on my other PR: https://github.com/grafana-tools/sdk/pull/52