### PR TITLE
Fix the definition of dashboard annotations to allow annotation types and tags

### DIFF
--- a/board.go
+++ b/board.go
@@ -112,17 +112,18 @@ type (
 		Value interface{} `json:"value"` // TODO select more precise type
 	}
 	Annotation struct {
-		Name       string  `json:"name"`
-		Datasource *string `json:"datasource"`
-		ShowLine   bool    `json:"showLine"`
-		IconColor  string  `json:"iconColor"`
-		LineColor  string  `json:"lineColor"`
-		IconSize   uint    `json:"iconSize"`
-		Enable     bool    `json:"enable"`
-		Query      string  `json:"query"`
-		TextField  string  `json:"textField"`
-		TagsField  string  `json:"tagsField"`
-		Type       string  `json:"tags"`
+		Name       string   `json:"name"`
+		Datasource *string  `json:"datasource"`
+		ShowLine   bool     `json:"showLine"`
+		IconColor  string   `json:"iconColor"`
+		LineColor  string   `json:"lineColor"`
+		IconSize   uint     `json:"iconSize"`
+		Enable     bool     `json:"enable"`
+		Query      string   `json:"query"`
+		TextField  string   `json:"textField"`
+		TagsField  string   `json:"tagsField"`
+		Tags       []string `json:"tags"`
+		Type       string   `json:"type"`
 	}
 )
 


### PR DESCRIPTION
While trying to setup dashboard annotations using this SDK, I noticed that the struct definition was incorrect and prevented me from creating them correctly. In particular defining the type and tags for a given annotation.

That's what I fix in this PR.