### PR TITLE
Fix gofmt error

### DIFF
--- a/rest-org.go
+++ b/rest-org.go
@@ -275,7 +275,7 @@ func (r *Client) UpdateActualOrgUser(user UserRole, uid uint) (StatusMessage, er
 	if raw, err = json.Marshal(user); err != nil {
 		return StatusMessage{}, err
 	}
-	if raw, _, err = r.post(fmt.Sprintf("api/org/users/%d", uid), nil, raw); err != nil {	
+	if raw, _, err = r.post(fmt.Sprintf("api/org/users/%d", uid), nil, raw); err != nil {
 		return StatusMessage{}, err
 	}
 	if err = json.Unmarshal(raw, &resp); err != nil {


### PR DESCRIPTION
Looks like the CI pipeline was failing because of some extra whitespaces.