### PR TITLE
integration: add admin tests, make things stricter

### DIFF
--- a/rest-admin_integration_test.go
+++ b/rest-admin_integration_test.go
@@ -1,0 +1,52 @@
+package sdk_test
+
+import (
+	"github.com/grafana-tools/sdk"
+	"testing"
+)
+
+func TestAdminOperations(t *testing.T) {
+	shouldSkip(t)
+	client := getClient()
+
+	u := sdk.User{
+		Login:          "test",
+		Name:           "name",
+		Email:          "grafana@sdk.com",
+		Theme:          "",
+		Password:       "vvvvvvvvvvvv",
+		IsGrafanaAdmin: false,
+	}
+
+	st, err := client.CreateUser(u)
+	if err != nil {
+		t.Fatalf("failed to create an user: %s", err.Error())
+	}
+	if st.Message != nil && *st.Message == "failed to create user" {
+		t.Fatal("failed to create an user for some unknown reason")
+	}
+
+	uid := *st.ID
+
+	retrievedUser, err := client.GetUser(uid)
+	if err != nil {
+		t.Fatalf("failed to get user: %s", err.Error())
+	}
+
+	if retrievedUser.Login != u.Login || retrievedUser.Email != u.Email {
+		t.Fatal("retrieved data does not match what was created")
+	}
+
+	_, err = client.UpdateUserPermissions(sdk.UserPermissions{IsGrafanaAdmin: true}, uid)
+	if err != nil {
+		t.Fatalf("failed to convert the user into an admin: %s", err)
+	}
+
+	retrievedUser, err = client.GetUser(uid)
+	if err != nil {
+		t.Fatalf("failed to get user: %s", err.Error())
+	}
+	if retrievedUser.IsGrafanaAdmin != true {
+		t.Fatal("user should be an admin but is not")
+	}
+}

--- a/rest-alertnotification_integration_test.go
+++ b/rest-alertnotification_integration_test.go
@@ -11,10 +11,10 @@ func Test_Alertnotification_CRUD(t *testing.T) {
 
 	alertnotifications, err := client.GetAllAlertNotifications()
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	if len(alertnotifications) != 0 {
-		t.Errorf("expected to get zero alertnotifications, got %#v", alertnotifications)
+		t.Fatalf("expected to get zero alertnotifications, got %#v", alertnotifications)
 	}
 
 	an := sdk.AlertNotification{
@@ -32,31 +32,31 @@ func Test_Alertnotification_CRUD(t *testing.T) {
 
 	id, err := client.CreateAlertNotification(an)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	anRetrieved, err := client.GetAlertNotificationID(uint(id))
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	if anRetrieved.Name != an.Name {
-		t.Errorf("got wrong name: expected %s, was %s", anRetrieved.Name, an.Name)
+		t.Fatalf("got wrong name: expected %s, was %s", anRetrieved.Name, an.Name)
 	}
 
 	an.Name = "alertnotification2"
 	err = client.UpdateAlertNotificationUID(an, "foobar")
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	err = client.DeleteAlertNotificationUID("foobar")
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	an, err = client.GetAlertNotificationUID("foobar")
 	if err == nil {
-		t.Errorf("expected the alertnotification to be deleted")
+		t.Fatalf("expected the alertnotification to be deleted")
 	}
 }

--- a/rest-datasource_integration_test.go
+++ b/rest-datasource_integration_test.go
@@ -12,10 +12,10 @@ func Test_Datasource_CRUD(t *testing.T) {
 
 	datasources, err := client.GetAllDatasources()
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	if len(datasources) != 0 {
-		t.Errorf("expected to get zero datasources, got %#v", datasources)
+		t.Fatalf("expected to get zero datasources, got %#v", datasources)
 	}
 
 	db := "grafanasdk"
@@ -35,32 +35,32 @@ func Test_Datasource_CRUD(t *testing.T) {
 
 	status, err := client.CreateDatasource(ds)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	dsRetrieved, err := client.GetDatasource(uint(*status.ID))
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	if dsRetrieved.Name != ds.Name {
-		t.Errorf("got wrong name: expected %s, was %s", dsRetrieved.Name, ds.Name)
+		t.Fatalf("got wrong name: expected %s, was %s", dsRetrieved.Name, ds.Name)
 	}
 
 	ds.Name = "elasticsdksource"
 	ds.ID = dsRetrieved.ID
 	status, err = client.UpdateDatasource(ds)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	_, err = client.DeleteDatasourceByName("elasticsdksource")
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	_, err = client.GetDatasource(uint(*status.ID))
 	if err == nil {
-		t.Errorf("expected the datasource to be deleted")
+		t.Fatalf("expected the datasource to be deleted")
 	}
 }


### PR DESCRIPTION
Use t.Fail{,f}() everywhere now to fail immediately once something goes
wrong because the tests are written in a way that we cannot continue if
something goes wrong.

Add initial integration tests for admin REST API calls.

Signed-off-by: Giedrius Statkevičius <giedriuswork@gmail.com>