### PR TITLE
Expose public structs instead of anonymous ones

### DIFF
--- a/panel.go
+++ b/panel.go
@@ -88,22 +88,26 @@ type (
 		Type        string  `json:"type"`
 		Alert       *Alert  `json:"alert,omitempty"`
 	}
-	AlertCondition struct {
-		Evaluator struct {
-			Params []float64 `json:"params,omitempty"`
-			Type   string    `json:"type,omitempty"`
-		} `json:"evaluator,omitempty"`
-		Operator struct {
-			Type string `json:"type,omitempty"`
-		} `json:"operator,omitempty"`
-		Query struct {
-			Params []string `json:"params,omitempty"`
-		} `json:"query,omitempty"`
-		Reducer struct {
-			Params []string `json:"params,omitempty"`
-			Type   string   `json:"type,omitempty"`
-		} `json:"reducer,omitempty"`
+	AlertEvaluator struct {
+		Params []float64 `json:"params,omitempty"`
+		Type   string    `json:"type,omitempty"`
+	}
+	AlertOperator struct {
 		Type string `json:"type,omitempty"`
+	}
+	AlertQuery struct {
+		Params []string `json:"params,omitempty"`
+	}
+	AlertReducer struct {
+		Params []string `json:"params,omitempty"`
+		Type   string   `json:"type,omitempty"`
+	}
+	AlertCondition struct {
+		Evaluator AlertEvaluator `json:"evaluator,omitempty"`
+		Operator  AlertOperator  `json:"operator,omitempty"`
+		Query     AlertQuery     `json:"query,omitempty"`
+		Reducer   AlertReducer   `json:"reducer,omitempty"`
+		Type      string         `json:"type,omitempty"`
 	}
 	Alert struct {
 		Conditions          []AlertCondition    `json:"conditions,omitempty"`
@@ -126,20 +130,7 @@ type (
 		Fill        int         `json:"fill"`
 		//		Grid        grid        `json:"grid"` obsoleted in 4.1 by xaxis and yaxis
 
-		Legend struct {
-			AlignAsTable bool  `json:"alignAsTable"`
-			Avg          bool  `json:"avg"`
-			Current      bool  `json:"current"`
-			HideEmpty    bool  `json:"hideEmpty"`
-			HideZero     bool  `json:"hideZero"`
-			Max          bool  `json:"max"`
-			Min          bool  `json:"min"`
-			RightSide    bool  `json:"rightSide"`
-			Show         bool  `json:"show"`
-			SideWidth    *uint `json:"sideWidth,omitempty"`
-			Total        bool  `json:"total"`
-			Values       bool  `json:"values"`
-		} `json:"legend,omitempty"`
+		Legend          Legend           `json:"legend,omitempty"`
 		LeftYAxisLabel  *string          `json:"leftYAxisLabel,omitempty"`
 		Lines           bool             `json:"lines"`
 		Linewidth       uint             `json:"linewidth"`
@@ -188,41 +179,29 @@ type (
 		Sort         int    `json:"sort,omitempty"`
 	}
 	TablePanel struct {
-		Columns []Column `json:"columns"`
-		Sort    *struct {
-			Col  uint `json:"col"`
-			Desc bool `json:"desc"`
-		} `json:"sort,omitempty"`
+		Columns   []Column      `json:"columns"`
+		Sort      *Sort         `json:"sort,omitempty"`
 		Styles    []ColumnStyle `json:"styles"`
 		Transform string        `json:"transform"`
 		Targets   []Target      `json:"targets,omitempty"`
 		Scroll    bool          `json:"scroll"` // from grafana 3.x
 	}
 	TextPanel struct {
-		Content    string `json:"content"`
-		Mode       string `json:"mode"`
-		PageSize   uint   `json:"pageSize"`
-		Scroll     bool   `json:"scroll"`
-		ShowHeader bool   `json:"showHeader"`
-		Sort       struct {
-			Col  int  `json:"col"`
-			Desc bool `json:"desc"`
-		} `json:"sort"`
-		Styles []ColumnStyle `json:"styles"`
+		Content    string        `json:"content"`
+		Mode       string        `json:"mode"`
+		PageSize   uint          `json:"pageSize"`
+		Scroll     bool          `json:"scroll"`
+		ShowHeader bool          `json:"showHeader"`
+		Sort       Sort          `json:"sort"`
+		Styles     []ColumnStyle `json:"styles"`
 	}
 	SinglestatPanel struct {
-		Colors          []string `json:"colors"`
-		ColorValue      bool     `json:"colorValue"`
-		ColorBackground bool     `json:"colorBackground"`
-		Decimals        int      `json:"decimals"`
-		Format          string   `json:"format"`
-		Gauge           struct {
-			MaxValue         float32 `json:"maxValue"`
-			MinValue         float32 `json:"minValue"`
-			Show             bool    `json:"show"`
-			ThresholdLabels  bool    `json:"thresholdLabels"`
-			ThresholdMarkers bool    `json:"thresholdMarkers"`
-		} `json:"gauge,omitempty"`
+		Colors          []string    `json:"colors"`
+		ColorValue      bool        `json:"colorValue"`
+		ColorBackground bool        `json:"colorBackground"`
+		Decimals        int         `json:"decimals"`
+		Format          string      `json:"format"`
+		Gauge           Gauge       `json:"gauge,omitempty"`
 		MappingType     *uint       `json:"mappingType,omitempty"`
 		MappingTypes    []*MapType  `json:"mappingTypes,omitempty"`
 		MaxDataPoints   *IntString  `json:"maxDataPoints,omitempty"`
@@ -232,19 +211,12 @@ type (
 		Prefix          *string     `json:"prefix,omitempty"`
 		PrefixFontSize  *string     `json:"prefixFontSize,omitempty"`
 		RangeMaps       []*RangeMap `json:"rangeMaps,omitempty"`
-		SparkLine       struct {
-			FillColor *string  `json:"fillColor,omitempty"`
-			Full      bool     `json:"full,omitempty"`
-			LineColor *string  `json:"lineColor,omitempty"`
-			Show      bool     `json:"show,omitempty"`
-			YMin      *float64 `json:"ymin,omitempty"`
-			YMax      *float64 `json:"ymax,omitempty"`
-		} `json:"sparkline,omitempty"`
-		Targets       []Target   `json:"targets,omitempty"`
-		Thresholds    string     `json:"thresholds"`
-		ValueFontSize string     `json:"valueFontSize"`
-		ValueMaps     []ValueMap `json:"valueMaps"`
-		ValueName     string     `json:"valueName"`
+		SparkLine       SparkLine   `json:"sparkline,omitempty"`
+		Targets         []Target    `json:"targets,omitempty"`
+		Thresholds      string      `json:"thresholds"`
+		ValueFontSize   string      `json:"valueFontSize"`
+		ValueMaps       []ValueMap  `json:"valueMaps"`
+		ValueName       string      `json:"valueName"`
 	}
 	DashlistPanel struct {
 		Mode  string   `json:"mode"`
@@ -315,6 +287,24 @@ type (
 		ZIndex        *int        `json:"zindex,omitempty"`
 		NullPointMode *string     `json:"nullPointMode,omitempty"`
 	}
+	Sort struct {
+		Col  int  `json:"col"`
+		Desc bool `json:"desc"`
+	}
+	Legend struct {
+		AlignAsTable bool  `json:"alignAsTable"`
+		Avg          bool  `json:"avg"`
+		Current      bool  `json:"current"`
+		HideEmpty    bool  `json:"hideEmpty"`
+		HideZero     bool  `json:"hideZero"`
+		Max          bool  `json:"max"`
+		Min          bool  `json:"min"`
+		RightSide    bool  `json:"rightSide"`
+		Show         bool  `json:"show"`
+		SideWidth    *uint `json:"sideWidth,omitempty"`
+		Total        bool  `json:"total"`
+		Values       bool  `json:"values"`
+	}
 )
 
 // for a table
@@ -337,11 +327,28 @@ type (
 )
 
 // for a singlestat
-type ValueMap struct {
-	Op       string `json:"op"`
-	TextType string `json:"text"`
-	Value    string `json:"value"`
-}
+type (
+	ValueMap struct {
+		Op       string `json:"op"`
+		TextType string `json:"text"`
+		Value    string `json:"value"`
+	}
+	Gauge struct {
+		MaxValue         float32 `json:"maxValue"`
+		MinValue         float32 `json:"minValue"`
+		Show             bool    `json:"show"`
+		ThresholdLabels  bool    `json:"thresholdLabels"`
+		ThresholdMarkers bool    `json:"thresholdMarkers"`
+	}
+	SparkLine struct {
+		FillColor *string  `json:"fillColor,omitempty"`
+		Full      bool     `json:"full,omitempty"`
+		LineColor *string  `json:"lineColor,omitempty"`
+		Show      bool     `json:"show,omitempty"`
+		YMin      *float64 `json:"ymin,omitempty"`
+		YMax      *float64 `json:"ymax,omitempty"`
+	}
+)
 
 // for an any panel
 type Target struct {


### PR DESCRIPTION
Makes it easier to use the SDK when public structs are given, instead of having to define our own/use anonymous ones.