### PR TITLE
*: run integration tests against 6.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ before_install:
  - go get golang.org/x/tools/cmd/cover
  - go get github.com/mattn/goveralls
  # Run Grafana
- - docker pull grafana/grafana:6.5.3
- - docker run --rm -d -p 3000:3000 grafana/grafana:6.5.3
+ - docker pull grafana/grafana:6.6.0
+ - docker run --rm -d -p 3000:3000 grafana/grafana:6.6.0
 
 # only one subpackage tested yet
 script:

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ datasources. State of support for misc API parts noted below.
 | Admin                       | partially                 |
 
 There is no exact roadmap.  The integration tests are being run against Grafana
-[6.5.3](/.travis.yml).
+[6.6.0](/.travis.yml).
 
 I still have interest to this library development but not always have
 time for it. So I gladly accept new contributions. Drop an issue or


### PR DESCRIPTION
Grafana 6.6.0 just came out, lets update!

Signed-off-by: Giedrius Statkevičius <giedriuswork@gmail.com>