### PR TITLE
Support 1.12/1.11 & multiple Grafana versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,57 @@
+---
 language: go
 
 services:
-- docker
+ - docker
 
-# Versions of go that are explicitly supported.
-go:
- - 1.13.x
- - 1.12.x
- - 1.11.x
-
-# Different Grafana versions.
+# Different Grafana + Go versions that will be tested.
 jobs:
  include:
-  - name: "Grafana 6.6.2"
-    env: "GRAFANA_VERSION=6.6.2"
-  - name: "Grafana 6.5.3"
-    env: "GRAFANA_VERSION=6.5.3"
-  - name: "Grafana 6.4.5"
-    env: "GRAFANA_VERSION=6.4.5"
-
-env:
- - GRAFANA_INTEGRATION=1
+  - name: "Grafana 6.6.2 1.13.x"
+    env:
+     - "GRAFANA_VERSION=6.6.2"
+     - "GRAFANA_INTEGRATION=1"
+    go: "1.13.x"
+  - name: "Grafana 6.5.3 1.13.x"
+    env:
+     - "GRAFANA_VERSION=6.5.3"
+     - "GRAFANA_INTEGRATION=1"
+    go: "1.13.x"
+  - name: "Grafana 6.4.5 1.13.x"
+    env:
+     - "GRAFANA_VERSION=6.4.5 1.13.x"
+     - "GRAFANA_INTEGRATION=1"
+    go: "1.13.x"
+  - name: "Grafana 6.6.2 1.12.x"
+    env:
+     - "GRAFANA_VERSION=6.6.2"
+     - "GRAFANA_INTEGRATION=1"
+    go: "1.12.x"
+  - name: "Grafana 6.5.3 1.12.x"
+    env:
+     - "GRAFANA_VERSION=6.5.3"
+     - "GRAFANA_INTEGRATION=1"
+    go: "1.12.x"
+  - name: "Grafana 6.4.5 1.12.x"
+    env:
+     - "GRAFANA_VERSION=6.4.5"
+     - "GRAFANA_INTEGRATION=1"
+    go: "1.12.x"
+  - name: "Grafana 6.6.2 1.11.x"
+    env:
+     - "GRAFANA_VERSION=6.6.2"
+     - "GRAFANA_INTEGRATION=1"
+    go: "1.11.x"
+  - name: "Grafana 6.5.3 1.11.x"
+    env:
+     - "GRAFANA_VERSION=6.5.3"
+     - "GRAFANA_INTEGRATION=1"
+    go: "1.11.x"
+  - name: "Grafana 6.4.5 1.11.x"
+    env:
+     - "GRAFANA_VERSION=6.4.5"
+     - "GRAFANA_INTEGRATION=1"
+    go: "1.11.x"
 
 # Required for coverage.
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,16 @@ go:
  - 1.12.x
  - 1.11.x
 
+# Different Grafana versions.
+jobs:
+ include:
+  - name: "Grafana 6.6.2"
+    env: "GRAFANA_VERSION=6.6.2"
+  - name: "Grafana 6.5.3"
+    env: "GRAFANA_VERSION=6.5.3"
+  - name: "Grafana 6.4.5"
+    env: "GRAFANA_VERSION=6.4.5"
+
 env:
  - GRAFANA_INTEGRATION=1
 
@@ -17,8 +27,8 @@ before_install:
  - go get golang.org/x/tools/cmd/cover
  - go get github.com/mattn/goveralls
  # Run Grafana
- - docker pull grafana/grafana:6.6.0
- - docker run --rm -d -p 3000:3000 grafana/grafana:6.6.0
+ - "docker pull grafana/grafana:$GRAFANA_VERSION"
+ - "docker run --rm -d -p 3000:3000 grafana/grafana:$GRAFANA_VERSION"
 
 # only one subpackage tested yet
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ services:
 # Versions of go that are explicitly supported.
 go:
  - 1.13.x
+ - 1.12.x
 
 env:
  - GRAFANA_INTEGRATION=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ services:
 go:
  - 1.13.x
  - 1.12.x
+ - 1.11.x
 
 env:
  - GRAFANA_INTEGRATION=1

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,6 @@ go 1.13
 
 require (
 	github.com/gosimple/slug v1.1.1
+	github.com/pkg/errors v0.9.1
 	github.com/rainycape/unidecode v0.0.0-20150907023854-cb7f23ec59be // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/gosimple/slug v1.1.1 h1:fRu/digW+NMwBIP+RmviTK97Ho/bEj/C9swrCspN3D4=
 github.com/gosimple/slug v1.1.1/go.mod h1:ER78kgg1Mv0NQGlXiDe57DpCyfbNywXXZ9mIorhxAf0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/rainycape/unidecode v0.0.0-20150907023854-cb7f23ec59be h1:ta7tUOvsPHVHGom5hKW5VXNc2xZIkfCKP8iaqOyYtUQ=
 github.com/rainycape/unidecode v0.0.0-20150907023854-cb7f23ec59be/go.mod h1:MIDFMn7db1kT65GmV94GzpX9Qdi7N/pQlwb+AN8wh+Q=

--- a/rest-annotation.go
+++ b/rest-annotation.go
@@ -155,5 +155,5 @@ func WithEndTime(t time.Time) GetAnnotationsParams {
 }
 
 func toMilliseconds(t time.Time) int64 {
-	return t.UnixNano() / 1_000_000
+	return t.UnixNano() / 1000000
 }

--- a/rest-annotation.go
+++ b/rest-annotation.go
@@ -6,6 +6,8 @@ import (
 	"net/url"
 	"strconv"
 	"time"
+
+	"github.com/pkg/errors"
 )
 
 // https://grafana.com/docs/grafana/latest/http_api/annotations/
@@ -18,13 +20,13 @@ func (r *Client) CreateAnnotation(a CreateAnnotationRequest) (StatusMessage, err
 		err  error
 	)
 	if raw, err = json.Marshal(a); err != nil {
-		return StatusMessage{}, fmt.Errorf("failed to marshal request: %w", err)
+		return StatusMessage{}, errors.Wrap(err, "marshal request")
 	}
 	if raw, _, err = r.post("api/annotations", nil, raw); err != nil {
-		return StatusMessage{}, fmt.Errorf("failed to create annotation: %w", err)
+		return StatusMessage{}, errors.Wrap(err, "create annotation")
 	}
 	if err = json.Unmarshal(raw, &resp); err != nil {
-		return StatusMessage{}, fmt.Errorf("failed to unmarshal response message: %w", err)
+		return StatusMessage{}, errors.Wrap(err, "unmarshal response message")
 	}
 	return resp, nil
 }
@@ -37,13 +39,13 @@ func (r *Client) PatchAnnotation(id uint, a PatchAnnotationRequest) (StatusMessa
 		err  error
 	)
 	if raw, err = json.Marshal(a); err != nil {
-		return StatusMessage{}, fmt.Errorf("failed to marshal request: %w", err)
+		return StatusMessage{}, errors.Wrap(err, "marshal request")
 	}
 	if raw, _, err = r.patch(fmt.Sprintf("api/annotations/%d", id), nil, raw); err != nil {
-		return StatusMessage{}, fmt.Errorf("failed to patch annotation: %w", err)
+		return StatusMessage{}, errors.Wrap(err, "patch annotation")
 	}
 	if err = json.Unmarshal(raw, &resp); err != nil {
-		return StatusMessage{}, fmt.Errorf("failed to unmarshal response message: %w", err)
+		return StatusMessage{}, errors.Wrap(err, "unmarshal response message")
 	}
 	return resp, nil
 }
@@ -62,10 +64,10 @@ func (r *Client) GetAnnotations(params ...GetAnnotationsParams) ([]AnnotationRes
 	}
 
 	if raw, _, err = r.get("api/annotations", requestParams); err != nil {
-		return nil, fmt.Errorf("failed to get annotations: %w", err)
+		return nil, errors.Wrap(err, "get annotations")
 	}
 	if err = json.Unmarshal(raw, &resp); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal response message: %w", err)
+		return nil, errors.Wrap(err, "unmarshal response message")
 	}
 	return resp, nil
 }
@@ -79,15 +81,15 @@ func (r *Client) DeleteAnnotation(id uint) (StatusMessage, error) {
 	)
 
 	if raw, _, err = r.delete(fmt.Sprintf("api/annotations/%d", id)); err != nil {
-		return StatusMessage{}, fmt.Errorf("failed to delete annotation: %w", err)
+		return StatusMessage{}, errors.Wrap(err, "delete annotation")
 	}
 	if err = json.Unmarshal(raw, &resp); err != nil {
-		return StatusMessage{}, fmt.Errorf("failed to unmarshal response message: %w", err)
+		return StatusMessage{}, errors.Wrap(err, "unmarshal response message")
 	}
 	return resp, nil
 }
 
-// AnnotationOption is the type for all options implementing query parameters
+// GetAnnotationsParams is the type for all options implementing query parameters
 // https://grafana.com/docs/grafana/latest/http_api/annotations/#find-annotations
 type GetAnnotationsParams func(values url.Values)
 

--- a/rest-annotation_integration_test.go
+++ b/rest-annotation_integration_test.go
@@ -51,7 +51,7 @@ func TestAnnotations(t *testing.T) {
 
 	ar := sdk.CreateAnnotationRequest{
 		Text: "test",
-		Time: time.Now().UnixNano() / 1_000_000,
+		Time: time.Now().UnixNano() / 1000000,
 	}
 	resp, err := client.CreateAnnotation(ar)
 	if err != nil {


### PR DESCRIPTION
It comes from a request at https://github.com/grafana-tools/sdk/pull/66#issuecomment-590750572. Doesn't take too much effort albeit it comes at the price of a dependency which allows us to handle error wrapping in a 1.11-1.13 compatible way.