### PR TITLE
updated add and remove Tag code

### DIFF
--- a/board.go
+++ b/board.go
@@ -172,17 +172,20 @@ func NewBoard(title string) *Board {
 		Timezone:     "browser",
 		Editable:     true,
 		HideControls: false,
-		Rows:         []*Row{}}
+		Rows:         []*Row{},
+	}
 }
 
 func (b *Board) RemoveTags(tags ...string) {
-	tagFound := make(map[string]int, len(b.Tags))
-	for i, tag := range b.Tags {
-		tagFound[tag] = i
-	}
-	for _, removeTag := range tags {
-		if i, ok := tagFound[removeTag]; ok {
-			b.Tags = append(b.Tags[:i], b.Tags[i+1:]...)
+	// order might change after removing the tags
+	for _, toRemoveTag := range tags {
+		tagLen := len(b.Tags)
+		for i, tag := range b.Tags {
+			if tag == toRemoveTag {
+				b.Tags[tagLen-1], b.Tags[i] = b.Tags[i], b.Tags[tagLen-1]
+				b.Tags = b.Tags[:tagLen-1]
+				break
+			}
 		}
 	}
 }
@@ -197,6 +200,7 @@ func (b *Board) AddTags(tags ...string) {
 			continue
 		}
 		b.Tags = append(b.Tags, tag)
+		tagFound[tag] = true
 	}
 }
 

--- a/board_test.go
+++ b/board_test.go
@@ -37,12 +37,18 @@ func TestAddTags(t *testing.T) {
 
 func TestBoardRemoveTags_Existent(t *testing.T) {
 	b := sdk.NewBoard("Sample")
-	b.AddTags("1", "2", "3", "4")
 
-	b.RemoveTags("1", "2")
+	b.AddTags("1", "2", "3", "4", "4")
+	b.RemoveTags("1", "2", "5")
+	b.AddTags("1", "4")
 
-	if len(b.Tags) != 2 {
-		t.Errorf("len(tags) should be 2 but got %d", len(b.Tags))
+	if len(b.Tags) != 3 {
+		t.Errorf("len(tags) should be 2 but got %d %v ", len(b.Tags), b.Tags)
+	}
+	for _, tag := range b.Tags {
+		if tag == "2" || tag == "5" {
+			t.Errorf("2 & 5 tag should not be present but got in tags %v", b.Tags)
+		}
 	}
 }
 


### PR DESCRIPTION
There were two issues with the previous ```RemoveTags``` and ```AddTags``` functions, both of them have been tested with UT. 

1. b.AddTags("1", "2", "3", "4", "4") 
- might add redundant tags. 
- It might be possible that it never happen but let's not take a chance. 

2. b.AddTags("1", "2", "3", "4")
    b.RemoveTags("1", "2", "5")
- In previous remove tag code we created a map of tags with``` index (position of tag)```
```map[string]int```
- when one element is deleted in the slice, order will change. 
- boom, bug is there. 

Both of the test cases were failing with previous code. It is fixed now. 