### PR TITLE
sdk: add context.Context to REST calls

### DIFF
--- a/cmd/backup-dashboards/main.go
+++ b/cmd/backup-dashboards/main.go
@@ -26,6 +26,7 @@ package main
 */
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -44,13 +45,14 @@ func main() {
 		fmt.Fprint(os.Stderr, "Usage:  backup-dashboards http://grafana.host:3000 api-key-string-here\n")
 		os.Exit(0)
 	}
+	ctx := context.Background()
 	c := sdk.NewClient(os.Args[1], os.Args[2], sdk.DefaultHTTPClient)
-	if boardLinks, err = c.SearchDashboards("", false); err != nil {
+	if boardLinks, err = c.SearchDashboards(ctx, "", false); err != nil {
 		fmt.Fprintf(os.Stderr, fmt.Sprintf("%s\n", err))
 		os.Exit(1)
 	}
 	for _, link := range boardLinks {
-		if rawBoard, meta, err = c.GetRawDashboardBySlug(link.URI); err != nil {
+		if rawBoard, meta, err = c.GetRawDashboardBySlug(ctx, link.URI); err != nil {
 			fmt.Fprintf(os.Stderr, fmt.Sprintf("%s for %s\n", err, link.URI))
 			continue
 		}

--- a/cmd/backup-datasources/main.go
+++ b/cmd/backup-datasources/main.go
@@ -26,6 +26,7 @@ package main
 */
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -46,8 +47,9 @@ func main() {
 		fmt.Fprint(os.Stderr, "Usage:  backup-datasources http://sdk.host:3000 api-key-string-here\n")
 		os.Exit(0)
 	}
+	ctx := context.Background()
 	c := sdk.NewClient(os.Args[1], os.Args[2], sdk.DefaultHTTPClient)
-	if datasources, err = c.GetAllDatasources(); err != nil {
+	if datasources, err = c.GetAllDatasources(ctx); err != nil {
 		fmt.Fprintf(os.Stderr, fmt.Sprintf("%s\n", err))
 		os.Exit(1)
 	}

--- a/cmd/import-dashboards-raw/main.go
+++ b/cmd/import-dashboards-raw/main.go
@@ -31,6 +31,7 @@ package main
 */
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -50,6 +51,7 @@ func main() {
 		fmt.Fprint(os.Stderr, "Usage: import-dashboards http://grafana.host:3000 api-key-string-here\n")
 		os.Exit(0)
 	}
+	ctx := context.Background()
 	c := sdk.NewClient(os.Args[1], os.Args[2], sdk.DefaultHTTPClient)
 	filesInDir, err = ioutil.ReadDir(".")
 	if err != nil {
@@ -61,7 +63,7 @@ func main() {
 				log.Println(err)
 				continue
 			}
-			_, err := c.SetRawDashboard(rawBoard)
+			_, err := c.SetRawDashboard(ctx, rawBoard)
 			if err != nil {
 				log.Printf("error on importing dashboard from %s", file.Name())
 				continue

--- a/cmd/import-dashboards/main.go
+++ b/cmd/import-dashboards/main.go
@@ -29,6 +29,7 @@ package main
 */
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -49,6 +50,7 @@ func main() {
 		fmt.Fprint(os.Stderr, "Usage: import-dashboards http://grafana-host:3000 api-key-string-here\n")
 		os.Exit(0)
 	}
+	ctx := context.Background()
 	c := sdk.NewClient(os.Args[1], os.Args[2], sdk.DefaultHTTPClient)
 	filesInDir, err = ioutil.ReadDir(".")
 	if err != nil {
@@ -65,8 +67,8 @@ func main() {
 				log.Println(err)
 				continue
 			}
-			c.DeleteDashboard(board.UpdateSlug())
-			_, err := c.SetDashboard(board, false)
+			c.DeleteDashboard(ctx, board.UpdateSlug())
+			_, err := c.SetDashboard(ctx, board, false)
 			if err != nil {
 				log.Printf("error on importing dashboard %s", board.Title)
 				continue

--- a/cmd/import-datasources/main.go
+++ b/cmd/import-datasources/main.go
@@ -29,6 +29,7 @@ package main
 */
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -50,8 +51,9 @@ func main() {
 		fmt.Fprint(os.Stderr, "Usage:  import-datasources http://sdk-host:3000 api-key-string-here\n")
 		os.Exit(0)
 	}
+	ctx := context.Background()
 	c := sdk.NewClient(os.Args[1], os.Args[2], sdk.DefaultHTTPClient)
-	if datasources, err = c.GetAllDatasources(); err != nil {
+	if datasources, err = c.GetAllDatasources(ctx); err != nil {
 		fmt.Fprintf(os.Stderr, fmt.Sprintf("%s\n", err))
 		os.Exit(1)
 	}
@@ -72,11 +74,11 @@ func main() {
 			}
 			for _, existingDS := range datasources {
 				if existingDS.Name == newDS.Name {
-					c.DeleteDatasource(existingDS.ID)
+					c.DeleteDatasource(ctx, existingDS.ID)
 					break
 				}
 			}
-			if status, err = c.CreateDatasource(newDS); err != nil {
+			if status, err = c.CreateDatasource(ctx, newDS); err != nil {
 				fmt.Fprint(os.Stderr, fmt.Sprintf("error on importing datasource %s with %s (%s)", newDS.Name, err, *status.Message))
 			}
 		}

--- a/rest-admin.go
+++ b/rest-admin.go
@@ -1,6 +1,7 @@
 package sdk
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 )
@@ -8,7 +9,7 @@ import (
 // CreateUser creates a new global user.
 // Requires basic authentication and that the authenticated user is a Grafana Admin.
 // Reflects POST /api/admin/users API call.
-func (r *Client) CreateUser(user User) (StatusMessage, error) {
+func (r *Client) CreateUser(ctx context.Context, user User) (StatusMessage, error) {
 	var (
 		raw  []byte
 		resp StatusMessage
@@ -17,7 +18,7 @@ func (r *Client) CreateUser(user User) (StatusMessage, error) {
 	if raw, err = json.Marshal(user); err != nil {
 		return StatusMessage{}, err
 	}
-	if raw, _, err = r.post("api/admin/users", nil, raw); err != nil {
+	if raw, _, err = r.post(ctx, "api/admin/users", nil, raw); err != nil {
 		return StatusMessage{}, err
 	}
 	if err = json.Unmarshal(raw, &resp); err != nil {
@@ -29,7 +30,7 @@ func (r *Client) CreateUser(user User) (StatusMessage, error) {
 // UpdateUserPermissions updates the permissions of a global user.
 // Requires basic authentication and that the authenticated user is a Grafana Admin.
 // Reflects PUT /api/admin/users/:userId/password API call.
-func (r *Client) UpdateUserPermissions(permissions UserPermissions, uid uint) (StatusMessage, error) {
+func (r *Client) UpdateUserPermissions(ctx context.Context, permissions UserPermissions, uid uint) (StatusMessage, error) {
 	var (
 		raw   []byte
 		reply StatusMessage
@@ -38,7 +39,7 @@ func (r *Client) UpdateUserPermissions(permissions UserPermissions, uid uint) (S
 	if raw, err = json.Marshal(permissions); err != nil {
 		return StatusMessage{}, err
 	}
-	if raw, _, err = r.put(fmt.Sprintf("api/admin/users/%d/permissions", uid), nil, raw); err != nil {
+	if raw, _, err = r.put(ctx, fmt.Sprintf("api/admin/users/%d/permissions", uid), nil, raw); err != nil {
 		return StatusMessage{}, err
 	}
 	err = json.Unmarshal(raw, &reply)
@@ -48,14 +49,14 @@ func (r *Client) UpdateUserPermissions(permissions UserPermissions, uid uint) (S
 // SwitchUserContext switches user context to the given organization.
 // Requires basic authentication and that the authenticated user is a Grafana Admin.
 // Reflects POST /api/users/:userId/using/:organizationId API call.
-func (r *Client) SwitchUserContext(uid uint, oid uint) (StatusMessage, error) {
+func (r *Client) SwitchUserContext(ctx context.Context, uid uint, oid uint) (StatusMessage, error) {
 	var (
 		raw  []byte
 		resp StatusMessage
 		err  error
 	)
 
-	if raw, _, err = r.post(fmt.Sprintf("/api/users/%d/using/%d", uid, oid), nil, raw); err != nil {
+	if raw, _, err = r.post(ctx, fmt.Sprintf("/api/users/%d/using/%d", uid, oid), nil, raw); err != nil {
 		return StatusMessage{}, err
 	}
 	if err = json.Unmarshal(raw, &resp); err != nil {

--- a/rest-admin_integration_test.go
+++ b/rest-admin_integration_test.go
@@ -1,6 +1,7 @@
 package sdk_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/grafana-tools/sdk"
@@ -9,6 +10,7 @@ import (
 func TestAdminOperations(t *testing.T) {
 	shouldSkip(t)
 	client := getClient(t)
+	ctx := context.Background()
 
 	u := sdk.User{
 		Login:          "test",
@@ -19,7 +21,7 @@ func TestAdminOperations(t *testing.T) {
 		IsGrafanaAdmin: false,
 	}
 
-	st, err := client.CreateUser(u)
+	st, err := client.CreateUser(ctx, u)
 	if err != nil {
 		t.Fatalf("failed to create an user: %s", err.Error())
 	}
@@ -29,7 +31,7 @@ func TestAdminOperations(t *testing.T) {
 
 	uid := *st.ID
 
-	retrievedUser, err := client.GetUser(uid)
+	retrievedUser, err := client.GetUser(ctx, uid)
 	if err != nil {
 		t.Fatalf("failed to get user: %s", err.Error())
 	}
@@ -38,12 +40,12 @@ func TestAdminOperations(t *testing.T) {
 		t.Fatal("retrieved data does not match what was created")
 	}
 
-	_, err = client.UpdateUserPermissions(sdk.UserPermissions{IsGrafanaAdmin: true}, uid)
+	_, err = client.UpdateUserPermissions(ctx, sdk.UserPermissions{IsGrafanaAdmin: true}, uid)
 	if err != nil {
 		t.Fatalf("failed to convert the user into an admin: %s", err)
 	}
 
-	retrievedUser, err = client.GetUser(uid)
+	retrievedUser, err = client.GetUser(ctx, uid)
 	if err != nil {
 		t.Fatalf("failed to get user: %s", err.Error())
 	}

--- a/rest-alertnotification.go
+++ b/rest-alertnotification.go
@@ -17,20 +17,21 @@ package sdk
 */
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 )
 
 // GetAllAlertNotifications gets all alert notification channels.
 // Reflects GET /api/alert-notifications API call.
-func (c *Client) GetAllAlertNotifications() ([]AlertNotification, error) {
+func (c *Client) GetAllAlertNotifications(ctx context.Context) ([]AlertNotification, error) {
 	var (
 		raw  []byte
 		an   []AlertNotification
 		code int
 		err  error
 	)
-	if raw, code, err = c.get("api/alert-notifications", nil); err != nil {
+	if raw, code, err = c.get(ctx, "api/alert-notifications", nil); err != nil {
 		return nil, err
 	}
 	if code != 200 {
@@ -42,14 +43,14 @@ func (c *Client) GetAllAlertNotifications() ([]AlertNotification, error) {
 
 // GetAlertNotificationUID gets the alert notification channel which has the specified uid.
 // Reflects GET /api/alert-notifications/uid/:uid API call.
-func (c *Client) GetAlertNotificationUID(uid string) (AlertNotification, error) {
+func (c *Client) GetAlertNotificationUID(ctx context.Context, uid string) (AlertNotification, error) {
 	var (
 		raw  []byte
 		an   AlertNotification
 		code int
 		err  error
 	)
-	if raw, code, err = c.get(fmt.Sprintf("api/alert-notifications/uid/%s", uid), nil); err != nil {
+	if raw, code, err = c.get(ctx, fmt.Sprintf("api/alert-notifications/uid/%s", uid), nil); err != nil {
 		return an, err
 	}
 	if code != 200 {
@@ -61,14 +62,14 @@ func (c *Client) GetAlertNotificationUID(uid string) (AlertNotification, error) 
 
 // GetAlertNotificationID gets the alert notification channel which has the specified id.
 // Reflects GET /api/alert-notifications/:id API call.
-func (c *Client) GetAlertNotificationID(id uint) (AlertNotification, error) {
+func (c *Client) GetAlertNotificationID(ctx context.Context, id uint) (AlertNotification, error) {
 	var (
 		raw  []byte
 		an   AlertNotification
 		code int
 		err  error
 	)
-	if raw, code, err = c.get(fmt.Sprintf("api/alert-notifications/%d", id), nil); err != nil {
+	if raw, code, err = c.get(ctx, fmt.Sprintf("api/alert-notifications/%d", id), nil); err != nil {
 		return an, err
 	}
 	if code != 200 {
@@ -80,7 +81,7 @@ func (c *Client) GetAlertNotificationID(id uint) (AlertNotification, error) {
 
 // CreateAlertNotification creates a new alert notification channel.
 // Reflects POST /api/alert-notifications API call.
-func (c *Client) CreateAlertNotification(an AlertNotification) (int64, error) {
+func (c *Client) CreateAlertNotification(ctx context.Context, an AlertNotification) (int64, error) {
 	var (
 		raw  []byte
 		code int
@@ -89,7 +90,7 @@ func (c *Client) CreateAlertNotification(an AlertNotification) (int64, error) {
 	if raw, err = json.Marshal(an); err != nil {
 		return -1, err
 	}
-	if raw, code, err = c.post(fmt.Sprintf("api/alert-notifications"), nil, raw); err != nil {
+	if raw, code, err = c.post(ctx, fmt.Sprintf("api/alert-notifications"), nil, raw); err != nil {
 		return -1, err
 	}
 	if code != 200 {
@@ -104,7 +105,7 @@ func (c *Client) CreateAlertNotification(an AlertNotification) (int64, error) {
 
 // UpdateAlertNotificationUID updates the specified alert notification channel.
 // Reflects PUT /api/alert-notifications/uid/:uid API call.
-func (c *Client) UpdateAlertNotificationUID(an AlertNotification, uid string) error {
+func (c *Client) UpdateAlertNotificationUID(ctx context.Context, an AlertNotification, uid string) error {
 	var (
 		raw  []byte
 		code int
@@ -113,7 +114,7 @@ func (c *Client) UpdateAlertNotificationUID(an AlertNotification, uid string) er
 	if raw, err = json.Marshal(an); err != nil {
 		return err
 	}
-	if raw, code, err = c.put(fmt.Sprintf("api/alert-notifications/uid/%s", uid), nil, raw); err != nil {
+	if raw, code, err = c.put(ctx, fmt.Sprintf("api/alert-notifications/uid/%s", uid), nil, raw); err != nil {
 		return err
 	}
 	if code != 200 {
@@ -124,7 +125,7 @@ func (c *Client) UpdateAlertNotificationUID(an AlertNotification, uid string) er
 
 // UpdateAlertNotificationID updates the specified alert notification channel.
 // Reflects PUT /api/alert-notifications/:id API call.
-func (c *Client) UpdateAlertNotificationID(an AlertNotification, id uint) error {
+func (c *Client) UpdateAlertNotificationID(ctx context.Context, an AlertNotification, id uint) error {
 	var (
 		raw  []byte
 		code int
@@ -133,7 +134,7 @@ func (c *Client) UpdateAlertNotificationID(an AlertNotification, id uint) error 
 	if raw, err = json.Marshal(an); err != nil {
 		return err
 	}
-	if raw, code, err = c.put(fmt.Sprintf("api/alert-notifications/%d", id), nil, raw); err != nil {
+	if raw, code, err = c.put(ctx, fmt.Sprintf("api/alert-notifications/%d", id), nil, raw); err != nil {
 		return err
 	}
 	if code != 200 {
@@ -144,13 +145,13 @@ func (c *Client) UpdateAlertNotificationID(an AlertNotification, id uint) error 
 
 // DeleteAlertNotificationUID deletes the specified alert notification channel.
 // Reflects DELETE /api/alert-notifications/uid/:uid API call.
-func (c *Client) DeleteAlertNotificationUID(uid string) error {
+func (c *Client) DeleteAlertNotificationUID(ctx context.Context, uid string) error {
 	var (
 		raw  []byte
 		code int
 		err  error
 	)
-	if raw, code, err = c.delete(fmt.Sprintf("api/alert-notifications/uid/%s", uid)); err != nil {
+	if raw, code, err = c.delete(ctx, fmt.Sprintf("api/alert-notifications/uid/%s", uid)); err != nil {
 		return err
 	}
 	if code != 200 {
@@ -161,13 +162,13 @@ func (c *Client) DeleteAlertNotificationUID(uid string) error {
 
 // DeleteAlertNotificationID deletes the specified alert notification channel.
 // Reflects DELETE /api/alert-notifications/:id API call.
-func (c *Client) DeleteAlertNotificationID(id uint) error {
+func (c *Client) DeleteAlertNotificationID(ctx context.Context, id uint) error {
 	var (
 		raw  []byte
 		code int
 		err  error
 	)
-	if raw, code, err = c.delete(fmt.Sprintf("api/alert-notifications/%d", id)); err != nil {
+	if raw, code, err = c.delete(ctx, fmt.Sprintf("api/alert-notifications/%d", id)); err != nil {
 		return err
 	}
 	if code != 200 {

--- a/rest-alertnotification_integration_test.go
+++ b/rest-alertnotification_integration_test.go
@@ -1,6 +1,7 @@
 package sdk_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/grafana-tools/sdk"
@@ -9,8 +10,9 @@ import (
 func Test_Alertnotification_CRUD(t *testing.T) {
 	shouldSkip(t)
 	client := getClient(t)
+	ctx := context.Background()
 
-	alertnotifications, err := client.GetAllAlertNotifications()
+	alertnotifications, err := client.GetAllAlertNotifications(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -31,12 +33,12 @@ func Test_Alertnotification_CRUD(t *testing.T) {
 		},
 	}
 
-	id, err := client.CreateAlertNotification(an)
+	id, err := client.CreateAlertNotification(ctx, an)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	anRetrieved, err := client.GetAlertNotificationID(uint(id))
+	anRetrieved, err := client.GetAlertNotificationID(ctx, uint(id))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -46,17 +48,17 @@ func Test_Alertnotification_CRUD(t *testing.T) {
 	}
 
 	an.Name = "alertnotification2"
-	err = client.UpdateAlertNotificationUID(an, "foobar")
+	err = client.UpdateAlertNotificationUID(ctx, an, "foobar")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = client.DeleteAlertNotificationUID("foobar")
+	err = client.DeleteAlertNotificationUID(ctx, "foobar")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	an, err = client.GetAlertNotificationUID("foobar")
+	an, err = client.GetAlertNotificationUID(ctx, "foobar")
 	if err == nil {
 		t.Fatalf("expected the alertnotification to be deleted")
 	}

--- a/rest-annotation.go
+++ b/rest-annotation.go
@@ -1,6 +1,7 @@
 package sdk
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -13,7 +14,7 @@ import (
 // https://grafana.com/docs/grafana/latest/http_api/annotations/
 
 // CreateAnnotation creates a new annotation from the annotation request
-func (r *Client) CreateAnnotation(a CreateAnnotationRequest) (StatusMessage, error) {
+func (r *Client) CreateAnnotation(ctx context.Context, a CreateAnnotationRequest) (StatusMessage, error) {
 	var (
 		raw  []byte
 		resp StatusMessage
@@ -22,7 +23,7 @@ func (r *Client) CreateAnnotation(a CreateAnnotationRequest) (StatusMessage, err
 	if raw, err = json.Marshal(a); err != nil {
 		return StatusMessage{}, errors.Wrap(err, "marshal request")
 	}
-	if raw, _, err = r.post("api/annotations", nil, raw); err != nil {
+	if raw, _, err = r.post(ctx, "api/annotations", nil, raw); err != nil {
 		return StatusMessage{}, errors.Wrap(err, "create annotation")
 	}
 	if err = json.Unmarshal(raw, &resp); err != nil {
@@ -32,7 +33,7 @@ func (r *Client) CreateAnnotation(a CreateAnnotationRequest) (StatusMessage, err
 }
 
 // PatchAnnotation patches the annotation with id with the request
-func (r *Client) PatchAnnotation(id uint, a PatchAnnotationRequest) (StatusMessage, error) {
+func (r *Client) PatchAnnotation(ctx context.Context, id uint, a PatchAnnotationRequest) (StatusMessage, error) {
 	var (
 		raw  []byte
 		resp StatusMessage
@@ -41,7 +42,7 @@ func (r *Client) PatchAnnotation(id uint, a PatchAnnotationRequest) (StatusMessa
 	if raw, err = json.Marshal(a); err != nil {
 		return StatusMessage{}, errors.Wrap(err, "marshal request")
 	}
-	if raw, _, err = r.patch(fmt.Sprintf("api/annotations/%d", id), nil, raw); err != nil {
+	if raw, _, err = r.patch(ctx, fmt.Sprintf("api/annotations/%d", id), nil, raw); err != nil {
 		return StatusMessage{}, errors.Wrap(err, "patch annotation")
 	}
 	if err = json.Unmarshal(raw, &resp); err != nil {
@@ -51,7 +52,7 @@ func (r *Client) PatchAnnotation(id uint, a PatchAnnotationRequest) (StatusMessa
 }
 
 // GetAnnotations gets annotations matching the annotation parameters
-func (r *Client) GetAnnotations(params ...GetAnnotationsParams) ([]AnnotationResponse, error) {
+func (r *Client) GetAnnotations(ctx context.Context, params ...GetAnnotationsParams) ([]AnnotationResponse, error) {
 	var (
 		raw           []byte
 		err           error
@@ -63,7 +64,7 @@ func (r *Client) GetAnnotations(params ...GetAnnotationsParams) ([]AnnotationRes
 		p(requestParams)
 	}
 
-	if raw, _, err = r.get("api/annotations", requestParams); err != nil {
+	if raw, _, err = r.get(ctx, "api/annotations", requestParams); err != nil {
 		return nil, errors.Wrap(err, "get annotations")
 	}
 	if err = json.Unmarshal(raw, &resp); err != nil {
@@ -73,14 +74,14 @@ func (r *Client) GetAnnotations(params ...GetAnnotationsParams) ([]AnnotationRes
 }
 
 // DeleteAnnotation deletes the annotation with id
-func (r *Client) DeleteAnnotation(id uint) (StatusMessage, error) {
+func (r *Client) DeleteAnnotation(ctx context.Context, id uint) (StatusMessage, error) {
 	var (
 		raw  []byte
 		err  error
 		resp StatusMessage
 	)
 
-	if raw, _, err = r.delete(fmt.Sprintf("api/annotations/%d", id)); err != nil {
+	if raw, _, err = r.delete(ctx, fmt.Sprintf("api/annotations/%d", id)); err != nil {
 		return StatusMessage{}, errors.Wrap(err, "delete annotation")
 	}
 	if err = json.Unmarshal(raw, &resp); err != nil {

--- a/rest-annotation_integration_test.go
+++ b/rest-annotation_integration_test.go
@@ -1,6 +1,7 @@
 package sdk_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -10,12 +11,13 @@ import (
 func TestAnnotations(t *testing.T) {
 	shouldSkip(t)
 	client := getClient(t)
+	ctx := context.Background()
 
 	ar := sdk.CreateAnnotationRequest{
 		Text: "test",
 		Time: time.Now().UnixNano() / 1000000,
 	}
-	resp, err := client.CreateAnnotation(ar)
+	resp, err := client.CreateAnnotation(ctx, ar)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -23,13 +25,13 @@ func TestAnnotations(t *testing.T) {
 	checkResponse(t, resp, "Annotation added")
 	id := *resp.ID
 
-	resp, err = client.PatchAnnotation(id, sdk.PatchAnnotationRequest{Text: "new text"})
+	resp, err = client.PatchAnnotation(ctx, id, sdk.PatchAnnotationRequest{Text: "new text"})
 	if err != nil {
 		t.Fatal(err)
 	}
 	checkResponse(t, resp, "Annotation patched")
 
-	anns, err := client.GetAnnotations(sdk.WithLimit(100))
+	anns, err := client.GetAnnotations(ctx, sdk.WithLimit(100))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -43,7 +45,7 @@ func TestAnnotations(t *testing.T) {
 		t.Errorf("annotation not found")
 	}
 
-	resp, err = client.DeleteAnnotation(id)
+	resp, err = client.DeleteAnnotation(ctx, id)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/rest-dashboard.go
+++ b/rest-dashboard.go
@@ -21,6 +21,7 @@ package sdk
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -51,8 +52,8 @@ type BoardProperties struct {
 // GetDashboardByUID loads a dashboard and its metadata from Grafana by dashboard uid.
 //
 // Reflects GET /api/dashboards/uid/:uid API call.
-func (r *Client) GetDashboardByUID(uid string) (Board, BoardProperties, error) {
-	return r.getDashboard("uid/" + uid)
+func (r *Client) GetDashboardByUID(ctx context.Context, uid string) (Board, BoardProperties, error) {
+	return r.getDashboard(ctx, "uid/"+uid)
 }
 
 // GetDashboardBySlug loads a dashboard and its metadata from Grafana by dashboard slug.
@@ -63,9 +64,9 @@ func (r *Client) GetDashboardByUID(uid string) (Board, BoardProperties, error) {
 //
 // Reflects GET /api/dashboards/db/:slug API call.
 // Deprecated: since Grafana v5 you should use uids. Use GetDashboardByUID() for that.
-func (r *Client) GetDashboardBySlug(slug string) (Board, BoardProperties, error) {
+func (r *Client) GetDashboardBySlug(ctx context.Context, slug string) (Board, BoardProperties, error) {
 	path := setPrefix(slug)
-	return r.getDashboard(path)
+	return r.getDashboard(ctx, path)
 }
 
 // getDashboard loads a dashboard from Grafana instance along with metadata for a dashboard.
@@ -74,8 +75,8 @@ func (r *Client) GetDashboardBySlug(slug string) (Board, BoardProperties, error)
 // be appended automatically.
 //
 // Reflects GET /api/dashboards/db/:slug API call.
-func (r *Client) getDashboard(path string) (Board, BoardProperties, error) {
-	raw, bp, err := r.getRawDashboard(path)
+func (r *Client) getDashboard(ctx context.Context, path string) (Board, BoardProperties, error) {
+	raw, bp, err := r.getRawDashboard(ctx, path)
 	if err != nil {
 		return Board{}, BoardProperties{}, errors.Wrap(err, "get raw dashboard")
 	}
@@ -106,7 +107,7 @@ func (r *Client) getDashboard(path string) (Board, BoardProperties, error) {
 //
 // Reflects GET /api/dashboards/db/:slug API call.
 // Deprecated: since Grafana v5 you should use uids. Use GetRawDashboardByUID() for that.
-func (r *Client) getRawDashboard(path string) ([]byte, BoardProperties, error) {
+func (r *Client) getRawDashboard(ctx context.Context, path string) ([]byte, BoardProperties, error) {
 	var (
 		raw    []byte
 		result struct {
@@ -116,7 +117,7 @@ func (r *Client) getRawDashboard(path string) ([]byte, BoardProperties, error) {
 		code int
 		err  error
 	)
-	if raw, code, err = r.get(fmt.Sprintf("api/dashboards/%s", path), nil); err != nil {
+	if raw, code, err = r.get(ctx, fmt.Sprintf("api/dashboards/%s", path), nil); err != nil {
 		return nil, BoardProperties{}, err
 	}
 	if code != 200 {
@@ -133,8 +134,8 @@ func (r *Client) getRawDashboard(path string) ([]byte, BoardProperties, error) {
 // GetRawDashboardByUID loads a dashboard and its metadata from Grafana by dashboard uid.
 //
 // Reflects GET /api/dashboards/uid/:uid API call.
-func (r *Client) GetRawDashboardByUID(uid string) ([]byte, BoardProperties, error) {
-	return r.getRawDashboard("uid/" + uid)
+func (r *Client) GetRawDashboardByUID(ctx context.Context, uid string) ([]byte, BoardProperties, error) {
+	return r.getRawDashboard(ctx, "uid/"+uid)
 }
 
 // GetRawDashboardBySlug loads a dashboard and its metadata from Grafana by dashboard slug.
@@ -145,9 +146,9 @@ func (r *Client) GetRawDashboardByUID(uid string) ([]byte, BoardProperties, erro
 //
 // Reflects GET /api/dashboards/db/:slug API call.
 // Deprecated: since Grafana v5 you should use uids. Use GetRawDashboardByUID() for that.
-func (r *Client) GetRawDashboardBySlug(slug string) ([]byte, BoardProperties, error) {
+func (r *Client) GetRawDashboardBySlug(ctx context.Context, slug string) ([]byte, BoardProperties, error) {
 	path := setPrefix(slug)
-	return r.getRawDashboard(path)
+	return r.getRawDashboard(ctx, path)
 }
 
 // FoundBoard keeps result of search with metadata of a dashboard.
@@ -165,7 +166,7 @@ type FoundBoard struct {
 // only starred dashboards and only for tags (logical OR applied to multiple tags).
 //
 // Reflects GET /api/search API call.
-func (r *Client) SearchDashboards(query string, starred bool, tags ...string) ([]FoundBoard, error) {
+func (r *Client) SearchDashboards(ctx context.Context, query string, starred bool, tags ...string) ([]FoundBoard, error) {
 	var (
 		raw    []byte
 		boards []FoundBoard
@@ -183,7 +184,7 @@ func (r *Client) SearchDashboards(query string, starred bool, tags ...string) ([
 	for _, tag := range tags {
 		q.Add("tag", tag)
 	}
-	if raw, code, err = r.get("api/search", q); err != nil {
+	if raw, code, err = r.get(ctx, "api/search", q); err != nil {
 		return nil, err
 	}
 	if code != 200 {
@@ -201,7 +202,7 @@ func (r *Client) SearchDashboards(query string, starred bool, tags ...string) ([
 // may be only loaded with HTTP API but not created or updated.
 //
 // Reflects POST /api/dashboards/db API call.
-func (r *Client) SetDashboard(board Board, overwrite bool) (StatusMessage, error) {
+func (r *Client) SetDashboard(ctx context.Context, board Board, overwrite bool) (StatusMessage, error) {
 	var (
 		isBoardFromDB bool
 		newBoard      struct {
@@ -224,7 +225,7 @@ func (r *Client) SetDashboard(board Board, overwrite bool) (StatusMessage, error
 	if raw, err = json.Marshal(newBoard); err != nil {
 		return StatusMessage{}, err
 	}
-	if raw, code, err = r.post("api/dashboards/db", nil, raw); err != nil {
+	if raw, code, err = r.post(ctx, "api/dashboards/db", nil, raw); err != nil {
 		return StatusMessage{}, err
 	}
 	if err = json.Unmarshal(raw, &resp); err != nil {
@@ -242,7 +243,7 @@ func (r *Client) SetDashboard(board Board, overwrite bool) (StatusMessage, error
 // may be only loaded with HTTP API but not created or updated.
 //
 // Reflects POST /api/dashboards/db API call.
-func (r *Client) SetRawDashboard(raw []byte) (StatusMessage, error) {
+func (r *Client) SetRawDashboard(ctx context.Context, raw []byte) (StatusMessage, error) {
 	var (
 		rawResp []byte
 		resp    StatusMessage
@@ -260,7 +261,7 @@ func (r *Client) SetRawDashboard(raw []byte) (StatusMessage, error) {
 	buf.WriteString(`{"dashboard":`)
 	buf.Write(raw)
 	buf.WriteString(`, "overwrite": true}`)
-	if rawResp, code, err = r.post("api/dashboards/db", nil, buf.Bytes()); err != nil {
+	if rawResp, code, err = r.post(ctx, "api/dashboards/db", nil, buf.Bytes()); err != nil {
 		return StatusMessage{}, err
 	}
 	if err = json.Unmarshal(rawResp, &resp); err != nil {
@@ -277,7 +278,7 @@ func (r *Client) SetRawDashboard(raw []byte) (StatusMessage, error) {
 // may be only loaded with HTTP API but not deteled.
 //
 // Reflects DELETE /api/dashboards/db/:slug API call.
-func (r *Client) DeleteDashboard(slug string) (StatusMessage, error) {
+func (r *Client) DeleteDashboard(ctx context.Context, slug string) (StatusMessage, error) {
 	var (
 		isBoardFromDB bool
 		raw           []byte
@@ -287,7 +288,7 @@ func (r *Client) DeleteDashboard(slug string) (StatusMessage, error) {
 	if slug, isBoardFromDB = cleanPrefix(slug); !isBoardFromDB {
 		return StatusMessage{}, errors.New("only database dashboards (with 'db/' prefix in a slug) can be removed")
 	}
-	if raw, _, err = r.delete(fmt.Sprintf("api/dashboards/db/%s", slug)); err != nil {
+	if raw, _, err = r.delete(ctx, fmt.Sprintf("api/dashboards/db/%s", slug)); err != nil {
 		return StatusMessage{}, err
 	}
 	err = json.Unmarshal(raw, &reply)

--- a/rest-dashboard_integration_test.go
+++ b/rest-dashboard_integration_test.go
@@ -1,6 +1,7 @@
 package sdk_test
 
 import (
+	"context"
 	"encoding/json"
 	"io/ioutil"
 	"testing"
@@ -15,7 +16,7 @@ func Test_Dashboard_CRUD(t *testing.T) {
 	)
 
 	shouldSkip(t)
-
+	ctx := context.Background()
 	client := getClient(t)
 
 	var board sdk.Board
@@ -25,22 +26,22 @@ func Test_Dashboard_CRUD(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client.DeleteDashboard(board.UpdateSlug())
-	if _, err = client.SetDashboard(board, false); err != nil {
+	client.DeleteDashboard(ctx, board.UpdateSlug())
+	if _, err = client.SetDashboard(ctx, board, false); err != nil {
 		t.Fatal(err)
 	}
 
-	if boardLinks, err = client.SearchDashboards("", false); err != nil {
+	if boardLinks, err = client.SearchDashboards(ctx, "", false); err != nil {
 		t.Fatal(err)
 	}
 
 	for _, link := range boardLinks {
-		_, _, err = client.GetDashboardByUID(link.UID)
+		_, _, err = client.GetDashboardByUID(ctx, link.UID)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		_, _, err = client.GetDashboardBySlug(link.URI)
+		_, _, err = client.GetDashboardBySlug(ctx, link.URI)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/rest-datasource.go
+++ b/rest-datasource.go
@@ -20,20 +20,21 @@ package sdk
 */
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 )
 
 // GetAllDatasources gets all datasources.
 // Reflects GET /api/datasources API call.
-func (r *Client) GetAllDatasources() ([]Datasource, error) {
+func (r *Client) GetAllDatasources(ctx context.Context) ([]Datasource, error) {
 	var (
 		raw  []byte
 		ds   []Datasource
 		code int
 		err  error
 	)
-	if raw, code, err = r.get("api/datasources", nil); err != nil {
+	if raw, code, err = r.get(ctx, "api/datasources", nil); err != nil {
 		return nil, err
 	}
 	if code != 200 {
@@ -45,14 +46,14 @@ func (r *Client) GetAllDatasources() ([]Datasource, error) {
 
 // GetDatasource gets an datasource by ID.
 // Reflects GET /api/datasources/:datasourceId API call.
-func (r *Client) GetDatasource(id uint) (Datasource, error) {
+func (r *Client) GetDatasource(ctx context.Context, id uint) (Datasource, error) {
 	var (
 		raw  []byte
 		ds   Datasource
 		code int
 		err  error
 	)
-	if raw, code, err = r.get(fmt.Sprintf("api/datasources/%d", id), nil); err != nil {
+	if raw, code, err = r.get(ctx, fmt.Sprintf("api/datasources/%d", id), nil); err != nil {
 		return ds, err
 	}
 	if code != 200 {
@@ -64,14 +65,14 @@ func (r *Client) GetDatasource(id uint) (Datasource, error) {
 
 // GetDatasourceByName gets an datasource by Name.
 // Reflects GET /api/datasources/name/:datasourceName API call.
-func (r *Client) GetDatasourceByName(name string) (Datasource, error) {
+func (r *Client) GetDatasourceByName(ctx context.Context, name string) (Datasource, error) {
 	var (
 		raw  []byte
 		ds   Datasource
 		code int
 		err  error
 	)
-	if raw, code, err = r.get(fmt.Sprintf("api/datasources/name/%s", name), nil); err != nil {
+	if raw, code, err = r.get(ctx, fmt.Sprintf("api/datasources/name/%s", name), nil); err != nil {
 		return ds, err
 	}
 	if code != 200 {
@@ -83,7 +84,7 @@ func (r *Client) GetDatasourceByName(name string) (Datasource, error) {
 
 // CreateDatasource creates a new datasource.
 // Reflects POST /api/datasources API call.
-func (r *Client) CreateDatasource(ds Datasource) (StatusMessage, error) {
+func (r *Client) CreateDatasource(ctx context.Context, ds Datasource) (StatusMessage, error) {
 	var (
 		raw  []byte
 		resp StatusMessage
@@ -92,7 +93,7 @@ func (r *Client) CreateDatasource(ds Datasource) (StatusMessage, error) {
 	if raw, err = json.Marshal(ds); err != nil {
 		return StatusMessage{}, err
 	}
-	if raw, _, err = r.post("api/datasources", nil, raw); err != nil {
+	if raw, _, err = r.post(ctx, "api/datasources", nil, raw); err != nil {
 		return StatusMessage{}, err
 	}
 	if err = json.Unmarshal(raw, &resp); err != nil {
@@ -103,7 +104,7 @@ func (r *Client) CreateDatasource(ds Datasource) (StatusMessage, error) {
 
 // UpdateDatasource updates a datasource from data passed in argument.
 // Reflects PUT /api/datasources/:datasourceId API call.
-func (r *Client) UpdateDatasource(ds Datasource) (StatusMessage, error) {
+func (r *Client) UpdateDatasource(ctx context.Context, ds Datasource) (StatusMessage, error) {
 	var (
 		raw  []byte
 		resp StatusMessage
@@ -112,7 +113,7 @@ func (r *Client) UpdateDatasource(ds Datasource) (StatusMessage, error) {
 	if raw, err = json.Marshal(ds); err != nil {
 		return StatusMessage{}, err
 	}
-	if raw, _, err = r.put(fmt.Sprintf("api/datasources/%d", ds.ID), nil, raw); err != nil {
+	if raw, _, err = r.put(ctx, fmt.Sprintf("api/datasources/%d", ds.ID), nil, raw); err != nil {
 		return StatusMessage{}, err
 	}
 	if err = json.Unmarshal(raw, &resp); err != nil {
@@ -123,13 +124,13 @@ func (r *Client) UpdateDatasource(ds Datasource) (StatusMessage, error) {
 
 // DeleteDatasource deletes an existing datasource by ID.
 // Reflects DELETE /api/datasources/:datasourceId API call.
-func (r *Client) DeleteDatasource(id uint) (StatusMessage, error) {
+func (r *Client) DeleteDatasource(ctx context.Context, id uint) (StatusMessage, error) {
 	var (
 		raw   []byte
 		reply StatusMessage
 		err   error
 	)
-	if raw, _, err = r.delete(fmt.Sprintf("api/datasources/%d", id)); err != nil {
+	if raw, _, err = r.delete(ctx, fmt.Sprintf("api/datasources/%d", id)); err != nil {
 		return StatusMessage{}, err
 	}
 	err = json.Unmarshal(raw, &reply)
@@ -138,13 +139,13 @@ func (r *Client) DeleteDatasource(id uint) (StatusMessage, error) {
 
 // DeleteDatasourceByName deletes an existing datasource by Name.
 // Reflects DELETE /api/datasources/name/:datasourceName API call.
-func (r *Client) DeleteDatasourceByName(name string) (StatusMessage, error) {
+func (r *Client) DeleteDatasourceByName(ctx context.Context, name string) (StatusMessage, error) {
 	var (
 		raw   []byte
 		reply StatusMessage
 		err   error
 	)
-	if raw, _, err = r.delete(fmt.Sprintf("api/datasources/name/%s", name)); err != nil {
+	if raw, _, err = r.delete(ctx, fmt.Sprintf("api/datasources/name/%s", name)); err != nil {
 		return StatusMessage{}, err
 	}
 	err = json.Unmarshal(raw, &reply)
@@ -153,14 +154,14 @@ func (r *Client) DeleteDatasourceByName(name string) (StatusMessage, error) {
 
 // GetDatasourceTypes gets all available plugins for the datasources.
 // Reflects GET /api/datasources/plugins API call.
-func (r *Client) GetDatasourceTypes() (map[string]DatasourceType, error) {
+func (r *Client) GetDatasourceTypes(ctx context.Context) (map[string]DatasourceType, error) {
 	var (
 		raw     []byte
 		dsTypes = make(map[string]DatasourceType)
 		code    int
 		err     error
 	)
-	if raw, code, err = r.get("api/datasources/plugins", nil); err != nil {
+	if raw, code, err = r.get(ctx, "api/datasources/plugins", nil); err != nil {
 		return nil, err
 	}
 	if code != 200 {

--- a/rest-datasource_integration_test.go
+++ b/rest-datasource_integration_test.go
@@ -1,6 +1,7 @@
 package sdk_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/grafana-tools/sdk"
@@ -10,8 +11,9 @@ func Test_Datasource_CRUD(t *testing.T) {
 	shouldSkip(t)
 
 	client := getClient(t)
+	ctx := context.Background()
 
-	datasources, err := client.GetAllDatasources()
+	datasources, err := client.GetAllDatasources(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -34,12 +36,12 @@ func Test_Datasource_CRUD(t *testing.T) {
 		},
 	}
 
-	status, err := client.CreateDatasource(ds)
+	status, err := client.CreateDatasource(ctx, ds)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	dsRetrieved, err := client.GetDatasource(uint(*status.ID))
+	dsRetrieved, err := client.GetDatasource(ctx, uint(*status.ID))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -50,17 +52,17 @@ func Test_Datasource_CRUD(t *testing.T) {
 
 	ds.Name = "elasticsdksource"
 	ds.ID = dsRetrieved.ID
-	status, err = client.UpdateDatasource(ds)
+	status, err = client.UpdateDatasource(ctx, ds)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = client.DeleteDatasourceByName("elasticsdksource")
+	_, err = client.DeleteDatasourceByName(ctx, "elasticsdksource")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = client.GetDatasource(uint(*status.ID))
+	_, err = client.GetDatasource(ctx, uint(*status.ID))
 	if err == nil {
 		t.Fatalf("expected the datasource to be deleted")
 	}

--- a/rest-folder.go
+++ b/rest-folder.go
@@ -20,6 +20,7 @@ package sdk
 */
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -30,7 +31,7 @@ import (
 
 // GetAllFolders gets all folders.
 // Reflects GET /api/folders API call.
-func (r *Client) GetAllFolders(params ...GetFolderParams) ([]Folder, error) {
+func (r *Client) GetAllFolders(ctx context.Context, params ...GetFolderParams) ([]Folder, error) {
 	var (
 		raw           []byte
 		fs            []Folder
@@ -41,7 +42,7 @@ func (r *Client) GetAllFolders(params ...GetFolderParams) ([]Folder, error) {
 	for _, p := range params {
 		p(requestParams)
 	}
-	if raw, code, err = r.get("api/folders", requestParams); err != nil {
+	if raw, code, err = r.get(ctx, "api/folders", requestParams); err != nil {
 		return nil, err
 	}
 	if code != 200 {
@@ -53,14 +54,14 @@ func (r *Client) GetAllFolders(params ...GetFolderParams) ([]Folder, error) {
 
 // GetFolderByUID gets folder by uid.
 // Reflects GET /api/folders/:uid API call.
-func (r *Client) GetFolderByUID(UID string) (Folder, error) {
+func (r *Client) GetFolderByUID(ctx context.Context, UID string) (Folder, error) {
 	var (
 		raw  []byte
 		f    Folder
 		code int
 		err  error
 	)
-	if raw, code, err = r.get(fmt.Sprintf("api/folders/%s", UID), nil); err != nil {
+	if raw, code, err = r.get(ctx, fmt.Sprintf("api/folders/%s", UID), nil); err != nil {
 		return f, err
 	}
 	if code != 200 {
@@ -72,7 +73,7 @@ func (r *Client) GetFolderByUID(UID string) (Folder, error) {
 
 // CreateFolder create folders.
 // Reflects POST /api/folders API call.
-func (r *Client) CreateFolder(f Folder) (Folder, error) {
+func (r *Client) CreateFolder(ctx context.Context, f Folder) (Folder, error) {
 	var (
 		raw  []byte
 		rf   Folder
@@ -83,7 +84,7 @@ func (r *Client) CreateFolder(f Folder) (Folder, error) {
 	if raw, err = json.Marshal(f); err != nil {
 		return rf, err
 	}
-	if raw, code, err = r.post("api/folders", nil, raw); err != nil {
+	if raw, code, err = r.post(ctx, "api/folders", nil, raw); err != nil {
 		return rf, err
 	}
 	if code != 200 {
@@ -95,7 +96,7 @@ func (r *Client) CreateFolder(f Folder) (Folder, error) {
 
 // UpdateFolderByUID update folder by uid
 // Reflects PUT /api/folders/:uid API call.
-func (r *Client) UpdateFolderByUID(f Folder) (Folder, error) {
+func (r *Client) UpdateFolderByUID(ctx context.Context, f Folder) (Folder, error) {
 	var (
 		raw  []byte
 		rf   Folder
@@ -106,7 +107,7 @@ func (r *Client) UpdateFolderByUID(f Folder) (Folder, error) {
 	if raw, err = json.Marshal(f); err != nil {
 		return rf, err
 	}
-	if raw, code, err = r.put(fmt.Sprintf("api/folders/%s", f.UID), nil, raw); err != nil {
+	if raw, code, err = r.put(ctx, fmt.Sprintf("api/folders/%s", f.UID), nil, raw); err != nil {
 		return rf, err
 	}
 	if code != 200 {
@@ -118,13 +119,13 @@ func (r *Client) UpdateFolderByUID(f Folder) (Folder, error) {
 
 // DeleteFolderByUID deletes an existing folder by uid.
 // Reflects DELETE /api/folders/:uid API call.
-func (r *Client) DeleteFolderByUID(UID string) (bool, error) {
+func (r *Client) DeleteFolderByUID(ctx context.Context, UID string) (bool, error) {
 	var (
 		raw  []byte
 		code int
 		err  error
 	)
-	if raw, code, err = r.delete(fmt.Sprintf("api/folders/%s", UID)); err != nil {
+	if raw, code, err = r.delete(ctx, fmt.Sprintf("api/folders/%s", UID)); err != nil {
 		return false, err
 	}
 	if code != 200 {
@@ -135,7 +136,7 @@ func (r *Client) DeleteFolderByUID(UID string) (bool, error) {
 
 // GetFolderByID gets folder by id.
 // Reflects GET /api/folders/id/:id API call.
-func (r *Client) GetFolderByID(ID int) (Folder, error) {
+func (r *Client) GetFolderByID(ctx context.Context, ID int) (Folder, error) {
 	var (
 		raw  []byte
 		f    Folder
@@ -145,7 +146,7 @@ func (r *Client) GetFolderByID(ID int) (Folder, error) {
 	if ID <= 0 {
 		return f, fmt.Errorf("ID cannot be less than zero")
 	}
-	if raw, code, err = r.get(fmt.Sprintf("api/folders/id/%d", ID), nil); err != nil {
+	if raw, code, err = r.get(ctx, fmt.Sprintf("api/folders/id/%d", ID), nil); err != nil {
 		return f, err
 	}
 	if code != 200 {

--- a/rest-folder_integration_test.go
+++ b/rest-folder_integration_test.go
@@ -1,21 +1,24 @@
 package sdk_test
 
 import (
-	"github.com/grafana-tools/sdk"
+	"context"
 	"testing"
+
+	"github.com/grafana-tools/sdk"
 )
 
 func Test_Folder_CRUD(t *testing.T) {
 	shouldSkip(t)
 
 	client := getClient(t)
+	ctx := context.Background()
 
 	var f1 = sdk.Folder{
 		Title: "test-folder-1",
 	}
 	var err error
 
-	fReceived1, err := client.CreateFolder(f1)
+	fReceived1, err := client.CreateFolder(ctx, f1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -27,7 +30,7 @@ func Test_Folder_CRUD(t *testing.T) {
 		Title: "test-folder-2",
 	}
 
-	fReceived2, err := client.CreateFolder(f2)
+	fReceived2, err := client.CreateFolder(ctx, f2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -35,7 +38,7 @@ func Test_Folder_CRUD(t *testing.T) {
 		t.Fatalf("got wrong title: expected %s, was %s", f2.Title, fReceived2.Title)
 	}
 
-	fs, err := client.GetAllFolders(sdk.Limit(1))
+	fs, err := client.GetAllFolders(ctx, sdk.Limit(1))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -43,7 +46,7 @@ func Test_Folder_CRUD(t *testing.T) {
 		t.Fatalf("expected to get one folders, got %d", len(fs))
 	}
 
-	fg, err := client.GetFolderByUID(fReceived1.UID)
+	fg, err := client.GetFolderByUID(ctx, fReceived1.UID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -51,7 +54,7 @@ func Test_Folder_CRUD(t *testing.T) {
 		t.Fatalf("got wrong title: expected %s, was %s", fReceived1.Title, fg.Title)
 	}
 
-	fg, err = client.GetFolderByID(fReceived1.ID)
+	fg, err = client.GetFolderByID(ctx, fReceived1.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -60,7 +63,7 @@ func Test_Folder_CRUD(t *testing.T) {
 	}
 
 	fReceived1.Title = "test-update-folder"
-	fg, err = client.UpdateFolderByUID(fReceived1)
+	fg, err = client.UpdateFolderByUID(ctx, fReceived1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -68,14 +71,14 @@ func Test_Folder_CRUD(t *testing.T) {
 		t.Fatalf("got wrong title: expected %s, was %s", fReceived1.Title, fg.Title)
 	}
 
-	r, err := client.DeleteFolderByUID(fReceived1.UID)
+	r, err := client.DeleteFolderByUID(ctx, fReceived1.UID)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !r {
 		t.Fatal("delete failed")
 	}
-	r, err = client.DeleteFolderByUID(fReceived2.UID)
+	r, err = client.DeleteFolderByUID(ctx, fReceived2.UID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/rest-get_health.go
+++ b/rest-get_health.go
@@ -20,6 +20,7 @@ package sdk
 */
 
 import (
+	"context"
 	"encoding/json"
 )
 
@@ -32,12 +33,12 @@ type HealthResponse struct {
 
 // GetHealth retrieves the health of the grafana server
 // Reflects GET BaseURL API call.
-func (r *Client) GetHealth() (HealthResponse, error) {
+func (r *Client) GetHealth(ctx context.Context) (HealthResponse, error) {
 	var (
 		raw []byte
 		err error
 	)
-	if raw, _, err = r.get("/api/health", nil); err != nil {
+	if raw, _, err = r.get(ctx, "/api/health", nil); err != nil {
 		return HealthResponse{}, err
 	}
 

--- a/rest-get_health_integration_test.go
+++ b/rest-get_health_integration_test.go
@@ -1,6 +1,7 @@
 package sdk_test
 
 import (
+	"context"
 	"testing"
 )
 
@@ -8,7 +9,7 @@ func TestClient_GetHealth(t *testing.T) {
 	shouldSkip(t)
 	client := getClient(t)
 
-	health, err := client.GetHealth()
+	health, err := client.GetHealth(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/rest-org.go
+++ b/rest-org.go
@@ -21,6 +21,7 @@ package sdk
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -28,7 +29,7 @@ import (
 
 // CreateOrg creates a new organization.
 // It reflects POST /api/orgs API call.
-func (r *Client) CreateOrg(org Org) (StatusMessage, error) {
+func (r *Client) CreateOrg(ctx context.Context, org Org) (StatusMessage, error) {
 	var (
 		raw  []byte
 		resp StatusMessage
@@ -37,7 +38,7 @@ func (r *Client) CreateOrg(org Org) (StatusMessage, error) {
 	if raw, err = json.Marshal(org); err != nil {
 		return StatusMessage{}, err
 	}
-	if raw, _, err = r.post("api/orgs", nil, raw); err != nil {
+	if raw, _, err = r.post(ctx, "api/orgs", nil, raw); err != nil {
 		return StatusMessage{}, err
 	}
 	if err = json.Unmarshal(raw, &resp); err != nil {
@@ -48,14 +49,14 @@ func (r *Client) CreateOrg(org Org) (StatusMessage, error) {
 
 // GetAllOrgs returns all organizations.
 // It reflects GET /api/orgs API call.
-func (r *Client) GetAllOrgs() ([]Org, error) {
+func (r *Client) GetAllOrgs(ctx context.Context) ([]Org, error) {
 	var (
 		raw  []byte
 		orgs []Org
 		code int
 		err  error
 	)
-	if raw, code, err = r.get("api/orgs", nil); err != nil {
+	if raw, code, err = r.get(ctx, "api/orgs", nil); err != nil {
 		return orgs, err
 	}
 
@@ -72,14 +73,14 @@ func (r *Client) GetAllOrgs() ([]Org, error) {
 
 // GetActualOrg gets current organization.
 // It reflects GET /api/org API call.
-func (r *Client) GetActualOrg() (Org, error) {
+func (r *Client) GetActualOrg(ctx context.Context) (Org, error) {
 	var (
 		raw  []byte
 		org  Org
 		code int
 		err  error
 	)
-	if raw, code, err = r.get("api/org", nil); err != nil {
+	if raw, code, err = r.get(ctx, "api/org", nil); err != nil {
 		return org, err
 	}
 	if code != http.StatusOK {
@@ -95,14 +96,14 @@ func (r *Client) GetActualOrg() (Org, error) {
 
 // GetOrgById gets organization by organization Id.
 // It reflects GET /api/orgs/:orgId API call.
-func (r *Client) GetOrgById(oid uint) (Org, error) {
+func (r *Client) GetOrgById(ctx context.Context, oid uint) (Org, error) {
 	var (
 		raw  []byte
 		org  Org
 		code int
 		err  error
 	)
-	if raw, code, err = r.get(fmt.Sprintf("api/orgs/%d", oid), nil); err != nil {
+	if raw, code, err = r.get(ctx, fmt.Sprintf("api/orgs/%d", oid), nil); err != nil {
 		return org, err
 	}
 
@@ -119,14 +120,14 @@ func (r *Client) GetOrgById(oid uint) (Org, error) {
 
 // GetOrgByOrgName gets organization by organization name.
 // It reflects GET /api/orgs/name/:orgName API call.
-func (r *Client) GetOrgByOrgName(name string) (Org, error) {
+func (r *Client) GetOrgByOrgName(ctx context.Context, name string) (Org, error) {
 	var (
 		raw  []byte
 		org  Org
 		code int
 		err  error
 	)
-	if raw, code, err = r.get(fmt.Sprintf("api/orgs/name/%s", name), nil); err != nil {
+	if raw, code, err = r.get(ctx, fmt.Sprintf("api/orgs/name/%s", name), nil); err != nil {
 		return org, err
 	}
 
@@ -143,7 +144,7 @@ func (r *Client) GetOrgByOrgName(name string) (Org, error) {
 
 // UpdateActualOrg updates current organization.
 // It reflects PUT /api/org API call.
-func (r *Client) UpdateActualOrg(org Org) (StatusMessage, error) {
+func (r *Client) UpdateActualOrg(ctx context.Context, org Org) (StatusMessage, error) {
 	var (
 		raw  []byte
 		resp StatusMessage
@@ -152,7 +153,7 @@ func (r *Client) UpdateActualOrg(org Org) (StatusMessage, error) {
 	if raw, err = json.Marshal(org); err != nil {
 		return StatusMessage{}, err
 	}
-	if raw, _, err = r.put("api/org", nil, raw); err != nil {
+	if raw, _, err = r.put(ctx, "api/org", nil, raw); err != nil {
 		return StatusMessage{}, err
 	}
 	if err = json.Unmarshal(raw, &resp); err != nil {
@@ -163,7 +164,7 @@ func (r *Client) UpdateActualOrg(org Org) (StatusMessage, error) {
 
 // UpdateOrg updates the organization identified by oid.
 // It reflects PUT /api/orgs/:orgId API call.
-func (r *Client) UpdateOrg(org Org, oid uint) (StatusMessage, error) {
+func (r *Client) UpdateOrg(ctx context.Context, org Org, oid uint) (StatusMessage, error) {
 	var (
 		raw  []byte
 		resp StatusMessage
@@ -172,7 +173,7 @@ func (r *Client) UpdateOrg(org Org, oid uint) (StatusMessage, error) {
 	if raw, err = json.Marshal(org); err != nil {
 		return StatusMessage{}, err
 	}
-	if raw, _, err = r.put(fmt.Sprintf("api/orgs/%d", oid), nil, raw); err != nil {
+	if raw, _, err = r.put(ctx, fmt.Sprintf("api/orgs/%d", oid), nil, raw); err != nil {
 		return StatusMessage{}, err
 	}
 	if err = json.Unmarshal(raw, &resp); err != nil {
@@ -183,13 +184,13 @@ func (r *Client) UpdateOrg(org Org, oid uint) (StatusMessage, error) {
 
 // DeleteOrg deletes the organization identified by the oid.
 // Reflects DELETE /api/orgs/:orgId API call.
-func (r *Client) DeleteOrg(oid uint) (StatusMessage, error) {
+func (r *Client) DeleteOrg(ctx context.Context, oid uint) (StatusMessage, error) {
 	var (
 		raw  []byte
 		resp StatusMessage
 		err  error
 	)
-	if raw, _, err = r.delete(fmt.Sprintf("api/orgs/%d", oid)); err != nil {
+	if raw, _, err = r.delete(ctx, fmt.Sprintf("api/orgs/%d", oid)); err != nil {
 		return StatusMessage{}, err
 	}
 	if err = json.Unmarshal(raw, &resp); err != nil {
@@ -200,14 +201,14 @@ func (r *Client) DeleteOrg(oid uint) (StatusMessage, error) {
 
 // GetActualOrgUsers get all users within the actual organisation.
 // Reflects GET /api/org/users API call.
-func (r *Client) GetActualOrgUsers() ([]OrgUser, error) {
+func (r *Client) GetActualOrgUsers(ctx context.Context) ([]OrgUser, error) {
 	var (
 		raw   []byte
 		users []OrgUser
 		code  int
 		err   error
 	)
-	if raw, code, err = r.get("api/org/users", nil); err != nil {
+	if raw, code, err = r.get(ctx, "api/org/users", nil); err != nil {
 		return nil, err
 	}
 	if code != http.StatusOK {
@@ -223,14 +224,14 @@ func (r *Client) GetActualOrgUsers() ([]OrgUser, error) {
 
 // GetOrgUsers gets the users for the organization specified by oid.
 // Reflects GET /api/orgs/:orgId/users API call.
-func (r *Client) GetOrgUsers(oid uint) ([]OrgUser, error) {
+func (r *Client) GetOrgUsers(ctx context.Context, oid uint) ([]OrgUser, error) {
 	var (
 		raw   []byte
 		users []OrgUser
 		code  int
 		err   error
 	)
-	if raw, code, err = r.get(fmt.Sprintf("api/orgs/%d/users", oid), nil); err != nil {
+	if raw, code, err = r.get(ctx, fmt.Sprintf("api/orgs/%d/users", oid), nil); err != nil {
 		return nil, err
 	}
 	if code != http.StatusOK {
@@ -246,7 +247,7 @@ func (r *Client) GetOrgUsers(oid uint) ([]OrgUser, error) {
 
 // AddActualOrgUser adds a global user to the current organization.
 // Reflects POST /api/org/users API call.
-func (r *Client) AddActualOrgUser(userRole UserRole) (StatusMessage, error) {
+func (r *Client) AddActualOrgUser(ctx context.Context, userRole UserRole) (StatusMessage, error) {
 	var (
 		raw  []byte
 		resp StatusMessage
@@ -255,7 +256,7 @@ func (r *Client) AddActualOrgUser(userRole UserRole) (StatusMessage, error) {
 	if raw, err = json.Marshal(userRole); err != nil {
 		return StatusMessage{}, err
 	}
-	if raw, _, err = r.post("api/org/users", nil, raw); err != nil {
+	if raw, _, err = r.post(ctx, "api/org/users", nil, raw); err != nil {
 		return StatusMessage{}, err
 	}
 	if err = json.Unmarshal(raw, &resp); err != nil {
@@ -264,9 +265,9 @@ func (r *Client) AddActualOrgUser(userRole UserRole) (StatusMessage, error) {
 	return resp, nil
 }
 
-// UpdateUser updates the existing user.
+// UpdateActualOrgUser updates the existing user.
 // Reflects POST /api/org/users/:userId API call.
-func (r *Client) UpdateActualOrgUser(user UserRole, uid uint) (StatusMessage, error) {
+func (r *Client) UpdateActualOrgUser(ctx context.Context, user UserRole, uid uint) (StatusMessage, error) {
 	var (
 		raw  []byte
 		resp StatusMessage
@@ -275,7 +276,7 @@ func (r *Client) UpdateActualOrgUser(user UserRole, uid uint) (StatusMessage, er
 	if raw, err = json.Marshal(user); err != nil {
 		return StatusMessage{}, err
 	}
-	if raw, _, err = r.post(fmt.Sprintf("api/org/users/%d", uid), nil, raw); err != nil {
+	if raw, _, err = r.post(ctx, fmt.Sprintf("api/org/users/%d", uid), nil, raw); err != nil {
 		return StatusMessage{}, err
 	}
 	if err = json.Unmarshal(raw, &resp); err != nil {
@@ -286,22 +287,22 @@ func (r *Client) UpdateActualOrgUser(user UserRole, uid uint) (StatusMessage, er
 
 // DeleteActualOrgUser delete user in actual organization.
 // Reflects DELETE /api/org/users/:userId API call.
-func (r *Client) DeleteActualOrgUser(uid uint) (StatusMessage, error) {
+func (r *Client) DeleteActualOrgUser(ctx context.Context, uid uint) (StatusMessage, error) {
 	var (
 		raw   []byte
 		reply StatusMessage
 		err   error
 	)
-	if raw, _, err = r.delete(fmt.Sprintf("api/org/users/%d", uid)); err != nil {
+	if raw, _, err = r.delete(ctx, fmt.Sprintf("api/org/users/%d", uid)); err != nil {
 		return StatusMessage{}, err
 	}
 	err = json.Unmarshal(raw, &reply)
 	return reply, err
 }
 
-// AddUserToOrg add user to organization with oid.
+// AddOrgUser add user to organization with oid.
 // Reflects POST /api/orgs/:orgId/users API call.
-func (r *Client) AddOrgUser(user UserRole, oid uint) (StatusMessage, error) {
+func (r *Client) AddOrgUser(ctx context.Context, user UserRole, oid uint) (StatusMessage, error) {
 	var (
 		raw   []byte
 		reply StatusMessage
@@ -310,7 +311,7 @@ func (r *Client) AddOrgUser(user UserRole, oid uint) (StatusMessage, error) {
 	if raw, err = json.Marshal(user); err != nil {
 		return StatusMessage{}, err
 	}
-	if raw, _, err = r.post(fmt.Sprintf("api/orgs/%d/users", oid), nil, raw); err != nil {
+	if raw, _, err = r.post(ctx, fmt.Sprintf("api/orgs/%d/users", oid), nil, raw); err != nil {
 		return StatusMessage{}, err
 	}
 	err = json.Unmarshal(raw, &reply)
@@ -319,7 +320,7 @@ func (r *Client) AddOrgUser(user UserRole, oid uint) (StatusMessage, error) {
 
 // UpdateOrgUser updates the user specified by uid within the organization specified by oid.
 // Reflects PATCH /api/orgs/:orgId/users/:userId API call.
-func (r *Client) UpdateOrgUser(user UserRole, oid, uid uint) (StatusMessage, error) {
+func (r *Client) UpdateOrgUser(ctx context.Context, user UserRole, oid, uid uint) (StatusMessage, error) {
 	var (
 		raw   []byte
 		reply StatusMessage
@@ -328,7 +329,7 @@ func (r *Client) UpdateOrgUser(user UserRole, oid, uid uint) (StatusMessage, err
 	if raw, err = json.Marshal(user); err != nil {
 		return StatusMessage{}, err
 	}
-	if raw, _, err = r.patch(fmt.Sprintf("api/orgs/%d/users/%d", oid, uid), nil, raw); err != nil {
+	if raw, _, err = r.patch(ctx, fmt.Sprintf("api/orgs/%d/users/%d", oid, uid), nil, raw); err != nil {
 		return StatusMessage{}, err
 	}
 	err = json.Unmarshal(raw, &reply)
@@ -337,13 +338,13 @@ func (r *Client) UpdateOrgUser(user UserRole, oid, uid uint) (StatusMessage, err
 
 // DeleteOrgUser deletes the user specified by uid within the organization specified by oid.
 // Reflects DELETE /api/orgs/:orgId/users/:userId API call.
-func (r *Client) DeleteOrgUser(oid, uid uint) (StatusMessage, error) {
+func (r *Client) DeleteOrgUser(ctx context.Context, oid, uid uint) (StatusMessage, error) {
 	var (
 		raw   []byte
 		reply StatusMessage
 		err   error
 	)
-	if raw, _, err = r.delete(fmt.Sprintf("api/orgs/%d/users/%d", oid, uid)); err != nil {
+	if raw, _, err = r.delete(ctx, fmt.Sprintf("api/orgs/%d/users/%d", oid, uid)); err != nil {
 		return StatusMessage{}, err
 	}
 	err = json.Unmarshal(raw, &reply)
@@ -352,7 +353,7 @@ func (r *Client) DeleteOrgUser(oid, uid uint) (StatusMessage, error) {
 
 // UpdateActualOrgPreferences updates preferences of the actual organization.
 // Reflects PUT /api/org/preferences API call.
-func (r *Client) UpdateActualOrgPreferences(prefs Preferences) (StatusMessage, error) {
+func (r *Client) UpdateActualOrgPreferences(ctx context.Context, prefs Preferences) (StatusMessage, error) {
 	var (
 		raw  []byte
 		resp StatusMessage
@@ -361,7 +362,7 @@ func (r *Client) UpdateActualOrgPreferences(prefs Preferences) (StatusMessage, e
 	if raw, err = json.Marshal(prefs); err != nil {
 		return StatusMessage{}, err
 	}
-	if raw, _, err = r.put("api/org/preferences/", nil, raw); err != nil {
+	if raw, _, err = r.put(ctx, "api/org/preferences/", nil, raw); err != nil {
 		return StatusMessage{}, err
 	}
 	if err = json.Unmarshal(raw, &resp); err != nil {
@@ -372,14 +373,14 @@ func (r *Client) UpdateActualOrgPreferences(prefs Preferences) (StatusMessage, e
 
 // GetActualOrgPreferences gets preferences of the actual organization.
 // It reflects GET /api/org/preferences API call.
-func (r *Client) GetActualOrgPreferences() (Preferences, error) {
+func (r *Client) GetActualOrgPreferences(ctx context.Context) (Preferences, error) {
 	var (
 		raw  []byte
 		pref Preferences
 		code int
 		err  error
 	)
-	if raw, code, err = r.get("/api/org/preferences", nil); err != nil {
+	if raw, code, err = r.get(ctx, "/api/org/preferences", nil); err != nil {
 		return pref, err
 	}
 

--- a/rest-org_integration_test.go
+++ b/rest-org_integration_test.go
@@ -1,6 +1,7 @@
 package sdk_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/grafana-tools/sdk"
@@ -10,16 +11,17 @@ func TestCreateDelete(t *testing.T) {
 	shouldSkip(t)
 
 	client := getClient(t)
+	ctx := context.Background()
 
 	oName := "coolorg"
 	o := sdk.Org{Name: oName}
-	statusMessage, err := client.CreateOrg(o)
+	statusMessage, err := client.CreateOrg(ctx, o)
 	if err != nil {
 		t.Fatalf("failed to create an org: %v (%s)", statusMessage, err.Error())
 	}
 	oID := *statusMessage.OrgID
 
-	retrievedOrg, err := client.GetOrgById(oID)
+	retrievedOrg, err := client.GetOrgById(ctx, oID)
 	if err != nil {
 		t.Fatalf("failed to retrieved org: %s", err.Error())
 	}
@@ -28,12 +30,12 @@ func TestCreateDelete(t *testing.T) {
 		t.Fatalf("got wrong org: got %s, expected %s", retrievedOrg.Name, o.Name)
 	}
 
-	_, err = client.DeleteOrg(oID)
+	_, err = client.DeleteOrg(ctx, oID)
 	if err != nil {
 		t.Fatalf("failed to delete org: %s", err.Error())
 	}
 
-	_, err = client.GetOrgById(oID)
+	_, err = client.GetOrgById(ctx, oID)
 	if err == nil {
 		t.Fatalf("org %s is still there even though it should be deleted", o.Name)
 	}

--- a/rest-request.go
+++ b/rest-request.go
@@ -97,10 +97,11 @@ func (r *Client) doRequest(ctx context.Context, method, query string, params url
 	if params != nil {
 		u.RawQuery = params.Encode()
 	}
-	req, err := http.NewRequestWithContext(ctx, method, u.String(), buf)
+	req, err := http.NewRequest(method, u.String(), buf)
 	if err != nil {
 		return nil, 0, err
 	}
+	req = req.WithContext(ctx)
 	if !r.basicAuth {
 		req.Header.Set("Authorization", r.key)
 	}

--- a/rest-request.go
+++ b/rest-request.go
@@ -21,6 +21,7 @@ package sdk
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -70,33 +71,33 @@ func NewClient(apiURL, apiKeyOrBasicAuth string, client *http.Client) *Client {
 	return &Client{baseURL: baseURL.String(), basicAuth: basicAuth, key: key, client: client}
 }
 
-func (r *Client) get(query string, params url.Values) ([]byte, int, error) {
-	return r.doRequest("GET", query, params, nil)
+func (r *Client) get(ctx context.Context, query string, params url.Values) ([]byte, int, error) {
+	return r.doRequest(ctx, "GET", query, params, nil)
 }
 
-func (r *Client) patch(query string, params url.Values, body []byte) ([]byte, int, error) {
-	return r.doRequest("PATCH", query, params, bytes.NewBuffer(body))
+func (r *Client) patch(ctx context.Context, query string, params url.Values, body []byte) ([]byte, int, error) {
+	return r.doRequest(ctx, "PATCH", query, params, bytes.NewBuffer(body))
 }
 
-func (r *Client) put(query string, params url.Values, body []byte) ([]byte, int, error) {
-	return r.doRequest("PUT", query, params, bytes.NewBuffer(body))
+func (r *Client) put(ctx context.Context, query string, params url.Values, body []byte) ([]byte, int, error) {
+	return r.doRequest(ctx, "PUT", query, params, bytes.NewBuffer(body))
 }
 
-func (r *Client) post(query string, params url.Values, body []byte) ([]byte, int, error) {
-	return r.doRequest("POST", query, params, bytes.NewBuffer(body))
+func (r *Client) post(ctx context.Context, query string, params url.Values, body []byte) ([]byte, int, error) {
+	return r.doRequest(ctx, "POST", query, params, bytes.NewBuffer(body))
 }
 
-func (r *Client) delete(query string) ([]byte, int, error) {
-	return r.doRequest("DELETE", query, nil, nil)
+func (r *Client) delete(ctx context.Context, query string) ([]byte, int, error) {
+	return r.doRequest(ctx, "DELETE", query, nil, nil)
 }
 
-func (r *Client) doRequest(method, query string, params url.Values, buf io.Reader) ([]byte, int, error) {
+func (r *Client) doRequest(ctx context.Context, method, query string, params url.Values, buf io.Reader) ([]byte, int, error) {
 	u, _ := url.Parse(r.baseURL)
 	u.Path = path.Join(u.Path, query)
 	if params != nil {
 		u.RawQuery = params.Encode()
 	}
-	req, err := http.NewRequest(method, u.String(), buf)
+	req, err := http.NewRequestWithContext(ctx, method, u.String(), buf)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/rest-user.go
+++ b/rest-user.go
@@ -21,6 +21,7 @@ package sdk
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -28,14 +29,14 @@ import (
 
 // GetActualUser gets an actual user.
 // Reflects GET /api/user API call.
-func (r *Client) GetActualUser() (User, error) {
+func (r *Client) GetActualUser(ctx context.Context) (User, error) {
 	var (
 		raw  []byte
 		user User
 		code int
 		err  error
 	)
-	if raw, code, err = r.get("api/user", nil); err != nil {
+	if raw, code, err = r.get(ctx, "api/user", nil); err != nil {
 		return user, err
 	}
 	if code != 200 {
@@ -51,14 +52,14 @@ func (r *Client) GetActualUser() (User, error) {
 
 // GetUser gets an user by ID.
 // Reflects GET /api/users/:id API call.
-func (r *Client) GetUser(id uint) (User, error) {
+func (r *Client) GetUser(ctx context.Context, id uint) (User, error) {
 	var (
 		raw  []byte
 		user User
 		code int
 		err  error
 	)
-	if raw, code, err = r.get(fmt.Sprintf("api/users/%d", id), nil); err != nil {
+	if raw, code, err = r.get(ctx, fmt.Sprintf("api/users/%d", id), nil); err != nil {
 		return user, err
 	}
 	if code != 200 {
@@ -74,7 +75,7 @@ func (r *Client) GetUser(id uint) (User, error) {
 
 // GetAllUsers gets all users.
 // Reflects GET /api/users API call.
-func (r *Client) GetAllUsers() ([]User, error) {
+func (r *Client) GetAllUsers(ctx context.Context) ([]User, error) {
 	var (
 		raw   []byte
 		users []User
@@ -84,7 +85,7 @@ func (r *Client) GetAllUsers() ([]User, error) {
 
 	params := url.Values{}
 	params.Set("perpage", "99999")
-	if raw, code, err = r.get("api/users", params); err != nil {
+	if raw, code, err = r.get(ctx, "api/users", params); err != nil {
 		return users, err
 	}
 	if code != 200 {
@@ -106,7 +107,7 @@ func (r *Client) GetAllUsers() ([]User, error) {
 // http://docs.grafana.org/http_api/user/#search-users-with-paging
 //
 // Reflects GET /api/users/search API call.
-func (r *Client) SearchUsersWithPaging(query *string, perpage, page *int) (PageUsers, error) {
+func (r *Client) SearchUsersWithPaging(ctx context.Context, query *string, perpage, page *int) (PageUsers, error) {
 	var (
 		raw       []byte
 		pageUsers PageUsers
@@ -130,7 +131,7 @@ func (r *Client) SearchUsersWithPaging(query *string, perpage, page *int) (PageU
 		params["query"] = []string{*query}
 	}
 
-	if raw, code, err = r.get("api/users/search", params); err != nil {
+	if raw, code, err = r.get(ctx, "api/users/search", params); err != nil {
 		return pageUsers, err
 	}
 	if code != 200 {

--- a/rest-user_integration_test.go
+++ b/rest-user_integration_test.go
@@ -1,6 +1,7 @@
 package sdk_test
 
 import (
+	"context"
 	"testing"
 )
 
@@ -8,13 +9,14 @@ func Test_User_SmokeTests(t *testing.T) {
 	shouldSkip(t)
 
 	client := getClient(t)
+	ctx := context.Background()
 
-	actualUser, err := client.GetActualUser()
+	actualUser, err := client.GetActualUser(ctx)
 	if err != nil {
 		t.Fatalf("failed to get actual user: %s", err.Error())
 	}
 
-	retrievedUser, err := client.GetUser(actualUser.ID)
+	retrievedUser, err := client.GetUser(ctx, actualUser.ID)
 	if err != nil {
 		t.Fatalf("failed to get user with ID %d: %s", actualUser.ID, err.Error())
 	}
@@ -23,7 +25,7 @@ func Test_User_SmokeTests(t *testing.T) {
 		t.Fatalf("retrieved a different user: %s vs. %s", actualUser.Name, retrievedUser.Name)
 	}
 
-	allUsers, err := client.GetAllUsers()
+	allUsers, err := client.GetAllUsers(ctx)
 	if err != nil {
 		t.Fatalf("failed to get all users: %s", err.Error())
 	}
@@ -46,7 +48,9 @@ func Test_User_SearchUsers(t *testing.T) {
 	shouldSkip(t)
 
 	client := getClient(t)
-	actualUser, err := client.GetActualUser()
+	ctx := context.Background()
+
+	actualUser, err := client.GetActualUser(ctx)
 	if err != nil {
 		t.Fatalf("failed to get actual user: %s", err.Error())
 	}
@@ -54,7 +58,7 @@ func Test_User_SearchUsers(t *testing.T) {
 	q := actualUser.Login
 	var currInd int = -1
 
-	if pgUsers, err := client.SearchUsersWithPaging(nil, nil, nil); err == nil {
+	if pgUsers, err := client.SearchUsersWithPaging(ctx, nil, nil, nil); err == nil {
 		for i, u := range pgUsers.Users {
 			if u.Login == q {
 				currInd = i
@@ -75,7 +79,7 @@ func Test_User_SearchUsers(t *testing.T) {
 	perPage := currInd + 1000
 	numPage := 1
 	nonExistentUser := "foobar"
-	afterUsers, err := client.SearchUsersWithPaging(&nonExistentUser, &perPage, &numPage)
+	afterUsers, err := client.SearchUsersWithPaging(ctx, &nonExistentUser, &perPage, &numPage)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Add `context.Context` as the first argument to functions which do
requests. This allows users to have fine-grained control over the
timeouts in the typical Go manner - they will not have to have the same
timeout on all operations that is set via `http.Client`.

This also informs our users that these functions do requests and that
they *do* block for a good reason - a HTTP request is made and then we
block until a response comes.

Closes #71 