### PR TITLE
Add Grafana dashboard search in specific folders

### DIFF
--- a/rest-dashboard_integration_test.go
+++ b/rest-dashboard_integration_test.go
@@ -10,11 +10,6 @@ import (
 )
 
 func Test_Dashboard_CRUD(t *testing.T) {
-	var (
-		boardLinks []sdk.FoundBoard
-		err        error
-	)
-
 	shouldSkip(t)
 	ctx := context.Background()
 	client := getClient(t)
@@ -22,33 +17,56 @@ func Test_Dashboard_CRUD(t *testing.T) {
 	var board sdk.Board
 	raw, _ := ioutil.ReadFile("testdata/new-empty-dashboard-2.6.json")
 
-	if err = json.Unmarshal(raw, &board); err != nil {
+	err := json.Unmarshal(raw, &board)
+	if err != nil {
 		t.Fatal(err)
 	}
 
+	// Check dashboard deletion.
 	client.DeleteDashboard(ctx, board.UpdateSlug())
+
+	// Check setting dashboard.
 	params := sdk.SetDashboardParams{
 		FolderID:  sdk.DefaultFolderId,
 		Overwrite: false,
 	}
-	if _, err = client.SetDashboard(ctx, board, params); err != nil {
+	_, err = client.SetDashboard(ctx, board, params)
+	if err != nil {
 		t.Fatal(err)
 	}
 
-	if boardLinks, err = client.SearchDashboards(ctx, "", false); err != nil {
+	// Check regular search of dashboards.
+	searchBoardLinks, err := client.SearchDashboards(ctx, "", false)
+	if err != nil {
 		t.Fatal(err)
 	}
-
-	if boardLinks, err = client.SearchDashboardsInFolders(ctx, []uint{1, 2}, "", false); err != nil {
-		t.Fatal(err)
-	}
-
-	for _, link := range boardLinks {
+	for _, link := range searchBoardLinks {
+		// Check dashboard retrieval by UID.
 		_, _, err = client.GetDashboardByUID(ctx, link.UID)
 		if err != nil {
 			t.Fatal(err)
 		}
 
+		// Check dashboard retrieval by Slug.
+		_, _, err = client.GetDashboardBySlug(ctx, link.URI)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Check searching dashboards inside folders.
+	searchInFolderBoardLinks, err := client.SearchDashboardsInFolders(ctx, []uint{0}, "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, link := range searchInFolderBoardLinks {
+		// Check dashboard retrieval by UID.
+		_, _, err = client.GetDashboardByUID(ctx, link.UID)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Check dashboard retrieval by Slug.
 		_, _, err = client.GetDashboardBySlug(ctx, link.URI)
 		if err != nil {
 			t.Fatal(err)

--- a/rest-dashboard_integration_test.go
+++ b/rest-dashboard_integration_test.go
@@ -39,6 +39,10 @@ func Test_Dashboard_CRUD(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	if boardLinks, err = client.SearchDashboardsInFolders(ctx, []uint{1, 2}, "", false); err != nil {
+		t.Fatal(err)
+	}
+
 	for _, link := range boardLinks {
 		_, _, err = client.GetDashboardByUID(ctx, link.UID)
 		if err != nil {


### PR DESCRIPTION
This PR adds the `folderIds` dashboard search filter so we can search the dashboards only on the folders we want.

A use case would be to create a dashboard backup replicating the folder structure.

I've added a new method so we don't break the API.