### PR TITLE
Set graph panel pointradius to float32 instead of int

### DIFF
--- a/panel.go
+++ b/panel.go
@@ -136,7 +136,7 @@ type (
 		Linewidth       uint             `json:"linewidth"`
 		NullPointMode   string           `json:"nullPointMode"`
 		Percentage      bool             `json:"percentage"`
-		Pointradius     int              `json:"pointradius"`
+		Pointradius     float32          `json:"pointradius"`
 		Points          bool             `json:"points"`
 		RightYAxisLabel *string          `json:"rightYAxisLabel,omitempty"`
 		SeriesOverrides []SeriesOverride `json:"seriesOverrides,omitempty"`


### PR DESCRIPTION
This PR changes graph panel `pointradius` attribute from `int` to `float32`.

Basically is because the field can be `0.5`, although this is not common, In my case, from >500 dashboards, only 4 of them have a graph with pointradious to `0.5` that make them fail being unmarshaled to the model:

```
json: cannot unmarshal number 0.5 into Go struct field Board.panels of type int
```

Regarding the [docs in Grafana's Grafonnet lib](https://grafana.github.io/grafonnet-lib/api-docs/#graphpanelnew).

> pointradius: Radius of the points, allowed values are 0.5 or [1 ... 10] with step 1

I didn't found any more information about the value type regarding this field.

