### PR TITLE
Allow targets to be hidden

### DIFF
--- a/panel.go
+++ b/panel.go
@@ -354,6 +354,7 @@ type (
 type Target struct {
 	RefID      string `json:"refId"`
 	Datasource string `json:"datasource,omitempty"`
+	Hide       bool   `json:"hide,omitempty"`
 
 	// For Prometheus
 	Expr           string `json:"expr,omitempty"`


### PR DESCRIPTION
In this PR, I allow targets (queries) to be hidden (the "eye" icon on the top right of the target definition form)
![grafana_targets](https://user-images.githubusercontent.com/66958/84270004-528a6880-ab2a-11ea-9ec0-e3fd7a29fcd3.png)

Hidden targets/queries are not sent to datasources by Grafana but can still be referenced in alerts.
