### PR TITLE
Add search, update for Alerts API

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ datasources. State of support for misc API parts noted below.
 | Snapshots                   | -                         |
 | Frontend settings           | -                         |
 | Admin                       | partially                 |
+| Alerting                    | partially                 |
 
 There is no exact roadmap.  The integration tests are being run against the
 following Grafana versions:

--- a/rest-alert.go
+++ b/rest-alert.go
@@ -1,0 +1,112 @@
+package sdk
+
+/*
+   Copyright 2016-2020 The Grafana SDK authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+	   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"time"
+)
+
+type (
+	AlertEvalMatch struct {
+		Metric string `json:"metric"`
+		Tags   struct {
+			ServiceName string `json:"service_name"`
+		} `json:"tags"`
+		Value int `json:"value"`
+	}
+	AlertEvalData struct {
+		EvalMatches []AlertEvalMatch `json:"evalMatches"`
+	}
+	FoundAlert struct {
+		ID             int           `json:"id"`
+		DashboardID    int           `json:"dashboardId"`
+		DashboardUID   string        `json:"dashboardUid"`
+		DashboardSlug  string        `json:"dashboardSlug"`
+		PanelID        int           `json:"panelId"`
+		Name           string        `json:"name"`
+		State          string        `json:"state"`
+		NewStateDate   time.Time     `json:"newStateDate"`
+		EvalDate       time.Time     `json:"evalDate"`
+		EvalData       AlertEvalData `json:"evalData"`
+		ExecutionError string        `json:"executionError"`
+		URL            string        `json:"url"`
+	}
+)
+
+// SearchAlerts searches for alerts with query params specified.SearchAlerts
+//
+// Refleects GET /api/alerts API call.
+func (r *Client) SearchAlerts(ctx context.Context, params ...SearchParam) ([]FoundAlert, error) {
+	var (
+		raw    []byte
+		alerts []FoundAlert
+		code   int
+		err    error
+	)
+	u := url.URL{}
+	q := u.Query()
+	for _, p := range params {
+		p(&q)
+	}
+	if raw, code, err = r.get(ctx, "api/alerts", q); err != nil {
+		return nil, err
+	}
+	if code != 200 {
+		return nil, fmt.Errorf("HTTP error %d: returns %s", code, raw)
+	}
+	err = json.Unmarshal(raw, &alerts)
+	return alerts, err
+}
+
+type AlertStatusMessage struct {
+	AlertID *int    `json:"alertId"`
+	State   *string `json:"state"`
+	Message *string `json:"message"`
+}
+
+// SetAlertPauseByID updates whether or not an alert is paused.SetAlertPauseByID
+//
+// Reflects POST /api/alerts/:id/pause
+func (r *Client) SetAlertPauseByID(ctx context.Context, id int, pause bool) (AlertStatusMessage, error) {
+	var (
+		setPauseStatus struct {
+			Paused bool `json:"paused"`
+		}
+		resp AlertStatusMessage
+		raw  []byte
+		code int
+		err  error
+	)
+	setPauseStatus.Paused = pause
+	if raw, err = json.Marshal(setPauseStatus); err != nil {
+		return AlertStatusMessage{}, err
+	}
+	if raw, code, err = r.post(ctx, fmt.Sprintf("api/alerts/%d/pause", id), nil, raw); err != nil {
+		return AlertStatusMessage{}, err
+	}
+	if err = json.Unmarshal(raw, &resp); err != nil {
+		return AlertStatusMessage{}, err
+	}
+	if code != 200 {
+		return resp, fmt.Errorf("HTTP error %d: returns %s", code, *resp.Message)
+	}
+	return resp, nil
+}

--- a/rest-alert_integration_test.go
+++ b/rest-alert_integration_test.go
@@ -1,0 +1,52 @@
+package sdk_test
+
+import (
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"testing"
+
+	"github.com/grafana-tools/sdk"
+)
+
+func Test_Alerts_Read(t *testing.T) {
+	shouldSkip(t)
+	client := getClient(t)
+	ctx := context.Background()
+
+	var board sdk.Board
+	raw, _ := ioutil.ReadFile("testdata/dashboard-with-alerts.json")
+	if err := json.Unmarshal(raw, &board); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := client.DeleteDashboard(ctx, board.UpdateSlug()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.SetDashboard(ctx, board, sdk.SetDashboardParams{
+		FolderID:  sdk.DefaultFolderId,
+		Overwrite: false,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	alerts, err := client.SearchAlerts(ctx, sdk.SearchDashboardID(int(board.ID)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(alerts) == 0 {
+		t.Fatal(err)
+	}
+	const sampleAlertName = "Sample alert"
+	var sampleAlertFound bool
+	for _, a := range alerts {
+		if a.Name == sampleAlertName {
+			sampleAlertFound = true
+			break
+		}
+	}
+	if !sampleAlertFound {
+		t.Fatal(err)
+	}
+}

--- a/testdata/dashboard-with-alerts.json
+++ b/testdata/dashboard-with-alerts.json
@@ -1,0 +1,104 @@
+{
+  "id": 182,
+  "title": "Sample dashboard with alerts",
+  "originalTitle": "Sample dashboard with panel",
+  "tags": [],
+  "style": "dark",
+  "timezone": "browser",
+  "editable": true,
+  "hideControls": false,
+  "sharedCrosshair": false,
+  "rows": [
+    {
+      "collapse": false,
+      "editable": true,
+      "height": "250px",
+      "panels": [
+        {
+          "editable": true,
+          "error": false,
+          "headings": true,
+          "id": 4,
+          "isNew": true,
+          "limit": 10,
+          "query": "",
+          "recent": false,
+          "search": false,
+          "span": 12,
+          "starred": true,
+          "tags": [],
+          "title": "Panel Title",
+          "type": "dashlist",
+          "alert": {
+            "conditions": [
+              {
+                "evaluator": {
+                  "params": [
+                    0
+                  ],
+                  "type": "gt"
+                },
+                "operator": {},
+                "query": {
+                  "params": [
+                    "A",
+                    "1m",
+                    "now"
+                  ]
+                },
+                "reducer": {
+                  "type": "max"
+                },
+                "type": "query"
+              }
+            ],
+            "executionErrorState": "alerting",
+            "for": "1m",
+            "frequency": "1m",
+            "name": "Sample alert",
+            "noDataState": "no_data"
+          }
+        }
+      ],
+      "title": "New row"
+    }
+  ],
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "templating": {
+    "list": []
+  },
+  "annotations": {
+    "list": []
+  },
+  "schemaVersion": 12,
+  "version": 0,
+  "links": []
+}


### PR DESCRIPTION
As described here: https://grafana.com/docs/grafana/latest/http_api/alerting/

I did not implement [Get alert by ID](https://grafana.com/docs/grafana/latest/http_api/alerting/#get-alert-by-id) because it seems bugged with our Grafana 7 deployment at least - the response does not give camelBack case but CamelCaps case (ie `Id` instead of `id`), unlike what is documented