### PR TITLE
Allow the project used by Stackdriver targets to be specified

### DIFF
--- a/panel.go
+++ b/panel.go
@@ -406,6 +406,7 @@ type Target struct {
 
 	// For the Stackdriver data source. Find out more information at
 	// https:/grafana.com/docs/grafana/v6.0/features/datasources/stackdriver/
+	ProjectName        string                    `json:"projectName,omitempty"`
 	AlignOptions       []StackdriverAlignOptions `json:"alignOptions,omitempty"`
 	AliasBy            string                    `json:"aliasBy,omitempty"`
 	MetricType         string                    `json:"metricType,omitempty"`


### PR DESCRIPTION
By default, Grafana will use the Google Cloud project defined in the JWT token given when creating the data source. In some cases, referencing another project while still using the same data source is desired.
For these use cases, I add the `ProjectName` field to the `Target` struct.