### PR TITLE
Support defining tags on alerts

### DIFF
--- a/panel.go
+++ b/panel.go
@@ -110,6 +110,7 @@ type (
 		Type      string         `json:"type,omitempty"`
 	}
 	Alert struct {
+		AlertRuleTags       map[string]string   `json:"alertRuleTags,omitempty"`
 		Conditions          []AlertCondition    `json:"conditions,omitempty"`
 		ExecutionErrorState string              `json:"executionErrorState,omitempty"`
 		Frequency           string              `json:"frequency,omitempty"`


### PR DESCRIPTION
In this PR, I allow the definition of tags on alerts. They will be sent to the notification channels used by the alerting rules (or at least the ones that support tags).

I don't know exactly when this has been introduced, but it has least has been available since Grafana v6.3 (https://grafana.com/docs/grafana/v6.3/alerting/notifications/)