### PR TITLE
Include folder information when searching for dashboards

### DIFF
--- a/rest-dashboard.go
+++ b/rest-dashboard.go
@@ -165,6 +165,11 @@ type FoundBoard struct {
 	Type      string   `json:"type"`
 	Tags      []string `json:"tags"`
 	IsStarred bool     `json:"isStarred"`
+
+	FolderID    string `json:"folderId"`
+	FolderUID   string `json:"folderUid"`
+	FolderTitle string `json:"folderTitle"`
+	FolderURL   string `json:"folderURL"`
 }
 
 // SearchDashboards search dashboards by substring of their title. It allows restrict the result set with


### PR DESCRIPTION
When a dashboard belongs to a folder, it will include which folder in the JSON response. The SDK currently does not parse this info out. 

e.g. an actual response
```json
{
"id":1,
"uid":"<redacted>",
"title":"Jobs Dashboard",
"uri":"<redacted>",
"url":"/dashboards/d/<redacted>/jobs-dashboard",
"slug":"",
"type":"dash-db",
"tags":[],
"isStarred":false,
"folderId":34,
"folderUid":"<redacted>",
"folderTitle":"Test Folder","folderUrl":"/dashboards/dashboards/f/<redacted>/test-folder"
}