### PR TITLE
Export link struct and add some helper methods

### DIFF
--- a/board.go
+++ b/board.go
@@ -61,7 +61,7 @@ type (
 		Refresh       *BoolString `json:"refresh,omitempty"`
 		SchemaVersion uint        `json:"schemaVersion"`
 		Version       uint        `json:"version"`
-		Links         []link      `json:"links"`
+		Links         []Link      `json:"links"`
 		Time          Time        `json:"time"`
 		Timepicker    Timepicker  `json:"timepicker"`
 		GraphTooltip  int         `json:"graphTooltip,omitempty"`
@@ -124,24 +124,23 @@ type (
 		Tags       []string `json:"tags"`
 		Type       string   `json:"type"`
 	}
+	// Link represents link to another dashboard or external weblink
+	Link struct {
+		Title       string   `json:"title"`
+		Type        string   `json:"type"`
+		AsDropdown  *bool    `json:"asDropdown,omitempty"`
+		DashURI     *string  `json:"dashUri,omitempty"`
+		Dashboard   *string  `json:"dashboard,omitempty"`
+		Icon        *string  `json:"icon,omitempty"`
+		IncludeVars bool     `json:"includeVars"`
+		KeepTime    *bool    `json:"keepTime,omitempty"`
+		Params      *string  `json:"params,omitempty"`
+		Tags        []string `json:"tags,omitempty"`
+		TargetBlank *bool    `json:"targetBlank,omitempty"`
+		Tooltip     *string  `json:"tooltip,omitempty"`
+		URL         *string  `json:"url,omitempty"`
+	}
 )
-
-// link represents link to another dashboard or external weblink
-type link struct {
-	Title       string   `json:"title"`
-	Type        string   `json:"type"`
-	AsDropdown  *bool    `json:"asDropdown,omitempty"`
-	DashURI     *string  `json:"dashUri,omitempty"`
-	Dashboard   *string  `json:"dashboard,omitempty"`
-	Icon        *string  `json:"icon,omitempty"`
-	IncludeVars bool     `json:"includeVars"`
-	KeepTime    *bool    `json:"keepTime,omitempty"`
-	Params      *string  `json:"params,omitempty"`
-	Tags        []string `json:"tags,omitempty"`
-	TargetBlank *bool    `json:"targetBlank,omitempty"`
-	Tooltip     *string  `json:"tooltip,omitempty"`
-	URL         *string  `json:"url,omitempty"`
-}
 
 // Height of rows maybe passed as number (ex 200) or
 // as string (ex "200px") or empty string
@@ -173,6 +172,10 @@ func NewBoard(title string) *Board {
 		HideControls: false,
 		Rows:         []*Row{},
 	}
+}
+
+func (b *Board) AddLink(link Link) {
+	b.Links = append(b.Links, link)
 }
 
 func (b *Board) RemoveTags(tags ...string) {

--- a/board_test.go
+++ b/board_test.go
@@ -90,3 +90,16 @@ func TestBoardHasTag_TagNotExists(t *testing.T) {
 		t.Error("tag not exists but found")
 	}
 }
+
+func TestBoardAddLink(t *testing.T) {
+  b := sdk.NewBoard("Sample")
+  b.AddLink(sdk.Link {
+    Title: "test",
+    Type: "external_link",
+    IncludeVars: false,
+  })
+
+  if len(b.Links) != 1 {
+		t.Error("Link wasn't added")
+  }
+}

--- a/panel.go
+++ b/panel.go
@@ -70,7 +70,7 @@ type (
 		HideTimeOverride *bool     `json:"hideTimeOverride,omitempty"`
 		ID               uint      `json:"id"`
 		IsNew            bool      `json:"isNew"`
-		Links            []link    `json:"links,omitempty"`    // general
+		Links            []Link    `json:"links,omitempty"`    // general
 		MinSpan          *float32  `json:"minSpan,omitempty"`  // templating options
 		OfType           panelType `json:"-"`                  // it required for defining type of the panel
 		Renderer         *string   `json:"renderer,omitempty"` // display styles


### PR DESCRIPTION
This commit exports the `link` struct in board.go, allowing users to
interact with the `link` field in Dashboards properly. 

Fixes #104 