### PR TITLE
user: Allow currently signed in user to change organizations

### DIFF
--- a/rest-user.go
+++ b/rest-user.go
@@ -144,3 +144,21 @@ func (r *Client) SearchUsersWithPaging(ctx context.Context, query *string, perpa
 	}
 	return pageUsers, err
 }
+
+// SwitchActualUserContext switches current user context to the given organization.
+// Reflects POST /api/user/using/:organizationId API call.
+func (r *Client) SwitchActualUserContext(ctx context.Context, oid uint) (StatusMessage, error) {
+	var (
+		raw  []byte
+		resp StatusMessage
+		err  error
+	)
+
+	if raw, _, err = r.post(ctx, fmt.Sprintf("/api/user/using/%d", oid), nil, raw); err != nil {
+		return StatusMessage{}, err
+	}
+	if err = json.Unmarshal(raw, &resp); err != nil {
+		return StatusMessage{}, err
+	}
+	return resp, nil
+}

--- a/rest-user_integration_test.go
+++ b/rest-user_integration_test.go
@@ -3,6 +3,8 @@ package sdk_test
 import (
 	"context"
 	"testing"
+
+	"github.com/grafana-tools/sdk"
 )
 
 func Test_User_SmokeTests(t *testing.T) {
@@ -92,5 +94,37 @@ func Test_User_SearchUsers(t *testing.T) {
 	}
 	if afterInd != -1 {
 		t.Fatal("actually found the user when we were not supposed to")
+	}
+}
+
+func Test_User_SwitchActualUserContext(t *testing.T) {
+	shouldSkip(t)
+
+	client := getClient(t)
+	ctx := context.Background()
+
+	const orgName = "Test Organization"
+	org := sdk.Org{
+		Name: orgName,
+	}
+
+	status, err := client.CreateOrg(ctx, org)
+	if err != nil {
+		t.Fatalf("failed to create organization '%s': %s", orgName, err.Error())
+	}
+
+	status, err = client.SwitchActualUserContext(ctx, *status.OrgID)
+	if err != nil {
+		t.Fatalf("failed to switch user context to new organization: %s", err.Error())
+	}
+
+	actualOrg, err := client.GetActualOrg(ctx)
+	if err != nil {
+		t.Fatalf("failed to get current organization: %s", err.Error())
+	}
+
+	if actualOrg.Name != orgName {
+		t.Fatalf("current organization is not the expected one. got: %s, want: %s",
+			actualOrg.Name, orgName)
 	}
 }


### PR DESCRIPTION
Adds a new method to allow the currently signed user to switch its context into a given organization (provided via the `organizationId`). This is particularly useful when trying to automate processes like generating tokens for a given organization as explained in: https://grafana.com/docs/grafana/latest/tutorials/api_org_token_howto/.

This PR reflects the `/api/user/using/:organizationId API` call.