### PR TITLE
Fix go 1.15 conversion from int to string

### DIFF
--- a/rest-user.go
+++ b/rest-user.go
@@ -120,8 +120,8 @@ func (r *Client) SearchUsersWithPaging(ctx context.Context, query *string, perpa
 		if params == nil {
 			params = url.Values{}
 		}
-		params["perpage"] = []string{string(*perpage)}
-		params["page"] = []string{string(*page)}
+		params["perpage"] = []string{fmt.Sprint(*perpage)}
+		params["page"] = []string{fmt.Sprint(*page)}
 	}
 
 	if query != nil {


### PR DESCRIPTION
Currently with go v1.15 it is not possible to build the project because of the deprecation of the `int` to `string` conversion. See https://github.com/golang/go/issues/32479.

I didn't include the Go 1.15 version in the README nor compatibility matrix because the change is backwards compatible. But it could be done eventually.