### PR TITLE
Add measurement field for InfluxDB targets

### DIFF
--- a/panel.go
+++ b/panel.go
@@ -390,6 +390,9 @@ type Target struct {
 	Instant        bool   `json:"instant,omitempty"`
 	Format         string `json:"format,omitempty"`
 
+	// For InfluxDB
+	Measurement string `json:"measurement,omitempty"`
+
 	// For Elasticsearch
 	DsType  *string `json:"dsType,omitempty"`
 	Metrics []struct {


### PR DESCRIPTION
Adds measurement field in `sdk.Target` to allow for marshalling/unmarshalling of panels that use InfluxDB as a datasource.

refs #114 