### PR TITLE
Add row panel case (grafana-tools#107)

### DIFF
--- a/panel.go
+++ b/panel.go
@@ -770,7 +770,7 @@ func (p *Panel) UnmarshalJSON(b []byte) (err error) {
 		case "row":
 			var rowpanel RowPanel
 			p.OfType = RowType
-			if err = json.Unmarshal(b, &rowpanel); err = nil {
+			if err = json.Unmarshal(b, &rowpanel); err == nil {
 				p.RowPanel = &rowpanel
 			}
 		default:

--- a/panel.go
+++ b/panel.go
@@ -767,6 +767,12 @@ func (p *Panel) UnmarshalJSON(b []byte) (err error) {
 			if err = json.Unmarshal(b, &dashlist); err == nil {
 				p.DashlistPanel = &dashlist
 			}
+		case "row":
+			var rowpanel RowPanel
+			p.OfType = RowType
+			if err = json.Unmarshal(b, &rowpanel); err = nil {
+				p.RowPanel = &rowpanel
+			}
 		default:
 			var custom = make(CustomPanel)
 			p.OfType = CustomType

--- a/panel.go
+++ b/panel.go
@@ -390,6 +390,9 @@ type Target struct {
 	Instant        bool   `json:"instant,omitempty"`
 	Format         string `json:"format,omitempty"`
 
+	// For InfluxDB
+	Measurement string `json:"measurement,omitempty"`
+
 	// For Elasticsearch
 	DsType  *string `json:"dsType,omitempty"`
 	Metrics []struct {


### PR DESCRIPTION
Credit to @jinnzy for the code. 

Refs #107 

This allows a row panel to be manipulated as a Row Panel type rather than a Custom Panel type and will have panels inside of the row that can be collapsed. 