### PR TITLE
Adding support for stat and bar gauge types

### DIFF
--- a/board.go
+++ b/board.go
@@ -107,7 +107,7 @@ type (
 	// for templateVar
 	Current struct {
 		Tags  []*string   `json:"tags,omitempty"`
-		Text  string      `json:"text"`
+		Text  interface{} `json:"text"`
 		Value interface{} `json:"value"` // TODO select more precise type
 	}
 	Annotation struct {

--- a/panel.go
+++ b/panel.go
@@ -161,6 +161,7 @@ type (
 	}
 	FieldConfig struct {
 		Defaults struct {
+			Unit      string `json:"unit"`
 			Threshold struct {
 				Mode  string `json:"mode"`
 				Steps []struct {
@@ -176,6 +177,7 @@ type (
 		ColorMode     string `json:"colorMode"`
 		GraphMode     string `json:"graphMode"`
 		JustifyMode   string `json:"justifyMode"`
+		DisplayMode   string `json:"displayMode"`
 		Content       string `json:"content"`
 		Mode          string `json:"mode"`
 		ReduceOptions struct {

--- a/panel.go
+++ b/panel.go
@@ -278,10 +278,15 @@ type (
 		Options         Options     `json:"options"`
 	}
 	DashlistPanel struct {
-		Mode  string   `json:"mode"`
-		Limit uint     `json:"limit"`
-		Query string   `json:"query"`
-		Tags  []string `json:"tags"`
+		Mode     string   `json:"mode"`
+		Query    string   `json:"query"`
+		Tags     []string `json:"tags"`
+		FolderID int      `json:"folderId"`
+		Limit    int      `json:"limit"`
+		Headings bool     `json:"headings"`
+		Recent   bool     `json:"recent"`
+		Search   bool     `json:"search"`
+		Starred  bool     `json:"starred"`
 	}
 	PluginlistPanel struct {
 		Limit int `json:"limit,omitempty"`

--- a/panel.go
+++ b/panel.go
@@ -809,6 +809,8 @@ func (p *Panel) GetTargets() *[]Target {
 	switch p.OfType {
 	case GraphType:
 		return &p.GraphPanel.Targets
+	case SinglestatType:
+		return &p.SinglestatPanel.Targets
 	case StatType:
 		return &p.StatPanel.Targets
 	case TableType:

--- a/panel_test.go
+++ b/panel_test.go
@@ -255,7 +255,7 @@ func TestNewGraph(t *testing.T) {
 	if graph.DashlistPanel != nil {
 		t.Error("should be nil")
 	}
-	if graph.StatPanel != nil {
+	if graph.SinglestatPanel != nil {
 		t.Error("should be nil")
 	}
 	if graph.Title != title {

--- a/panel_test.go
+++ b/panel_test.go
@@ -255,7 +255,7 @@ func TestNewGraph(t *testing.T) {
 	if graph.DashlistPanel != nil {
 		t.Error("should be nil")
 	}
-	if graph.SinglestatPanel != nil {
+	if graph.StatPanel != nil {
 		t.Error("should be nil")
 	}
 	if graph.Title != title {

--- a/rest-dashboard.go
+++ b/rest-dashboard.go
@@ -38,20 +38,23 @@ const DefaultFolderId = 0
 
 // BoardProperties keeps metadata of a dashboard.
 type BoardProperties struct {
-	IsStarred  bool      `json:"isStarred,omitempty"`
-	IsHome     bool      `json:"isHome,omitempty"`
-	IsSnapshot bool      `json:"isSnapshot,omitempty"`
-	Type       string    `json:"type,omitempty"`
-	CanSave    bool      `json:"canSave"`
-	CanEdit    bool      `json:"canEdit"`
-	CanStar    bool      `json:"canStar"`
-	Slug       string    `json:"slug"`
-	Expires    time.Time `json:"expires"`
-	Created    time.Time `json:"created"`
-	Updated    time.Time `json:"updated"`
-	UpdatedBy  string    `json:"updatedBy"`
-	CreatedBy  string    `json:"createdBy"`
-	Version    int       `json:"version"`
+	IsStarred   bool      `json:"isStarred,omitempty"`
+	IsHome      bool      `json:"isHome,omitempty"`
+	IsSnapshot  bool      `json:"isSnapshot,omitempty"`
+	Type        string    `json:"type,omitempty"`
+	CanSave     bool      `json:"canSave"`
+	CanEdit     bool      `json:"canEdit"`
+	CanStar     bool      `json:"canStar"`
+	Slug        string    `json:"slug"`
+	Expires     time.Time `json:"expires"`
+	Created     time.Time `json:"created"`
+	Updated     time.Time `json:"updated"`
+	UpdatedBy   string    `json:"updatedBy"`
+	CreatedBy   string    `json:"createdBy"`
+	Version     int       `json:"version"`
+	FolderID    int       `json:"folderId"`
+	FolderTitle string    `json:"folderTitle"`
+	FolderURL   string    `json:"folderUrl"`
 }
 
 // GetDashboardByUID loads a dashboard and its metadata from Grafana by dashboard uid.
@@ -158,13 +161,16 @@ func (r *Client) GetRawDashboardBySlug(ctx context.Context, slug string) ([]byte
 
 // FoundBoard keeps result of search with metadata of a dashboard.
 type FoundBoard struct {
-	ID        uint     `json:"id"`
-	UID       string   `json:"uid"`
-	Title     string   `json:"title"`
-	URI       string   `json:"uri"`
-	Type      string   `json:"type"`
-	Tags      []string `json:"tags"`
-	IsStarred bool     `json:"isStarred"`
+	ID          uint     `json:"id"`
+	UID         string   `json:"uid"`
+	Title       string   `json:"title"`
+	URI         string   `json:"uri"`
+	Type        string   `json:"type"`
+	Tags        []string `json:"tags"`
+	IsStarred   bool     `json:"isStarred"`
+	FolderID    int      `json:"folderId"`
+	FolderTitle string   `json:"folderTitle"`
+	FolderURL   string   `json:"folderUrl"`
 }
 
 // SearchDashboards search dashboards by substring of their title. It allows restrict the result set with

--- a/row.go
+++ b/row.go
@@ -70,11 +70,19 @@ func (r *Row) AddText(data *TextPanel) {
 	r.Panels = append(r.Panels, *panel)
 }
 
-func (r *Row) AddSinglestat(data *StatPanel) {
+func (r *Row) AddStat(data *StatPanel) {
 	lastPanelID++
 	panel := NewStat("")
 	panel.ID = lastPanelID
 	panel.StatPanel = data
+	r.Panels = append(r.Panels, *panel)
+}
+
+func (r *Row) AddSinglestat(data *SinglestatPanel) {
+	lastPanelID++
+	panel := NewSinglestat("")
+	panel.ID = lastPanelID
+	panel.SinglestatPanel = data
 	r.Panels = append(r.Panels, *panel)
 }
 

--- a/row.go
+++ b/row.go
@@ -70,11 +70,11 @@ func (r *Row) AddText(data *TextPanel) {
 	r.Panels = append(r.Panels, *panel)
 }
 
-func (r *Row) AddSinglestat(data *SinglestatPanel) {
+func (r *Row) AddSinglestat(data *StatPanel) {
 	lastPanelID++
-	panel := NewSinglestat("")
+	panel := NewStat("")
 	panel.ID = lastPanelID
-	panel.SinglestatPanel = data
+	panel.StatPanel = data
 	r.Panels = append(r.Panels, *panel)
 }
 


### PR DESCRIPTION
Chang-set:
* Add support for **stat** and **bargauge** panel types
* Mapping _FieldConfigs_ and _Options_
* Updating panel _Description_ field

I was trying to automate some parts of the grafana(7.1.1) dashboard panels provisioning with the golang SDK, however, I ran into a few API issues.

It looks like _master_ is up to date with the **6.x** API, but I don't see a **7.x** branch in the repo.
Looking back at the PR, I realize that some changes will break the existing contracts.


What is the preferred approach moving forward with **7.x** support?

I haven't done a detailed comparison, but it seems that the move from **6** -> **7** will break some APIs and I'm not sure if it will be possible to provide backwards compatibility using a single data model.

In any case, let me know since I have a live grafana **7** deployment that I can use to test out the migration.