### PR TITLE
board(annotations): support prometheus annotations

### DIFF
--- a/board.go
+++ b/board.go
@@ -120,6 +120,7 @@ type (
 		Enable     bool     `json:"enable"`
 		Query      string   `json:"query"`
 		Expr       string   `json:"expr"`
+		Step       string   `json:"step"`
 		TextField  string   `json:"textField"`
 		TagsField  string   `json:"tagsField"`
 		Tags       []string `json:"tags"`

--- a/board.go
+++ b/board.go
@@ -119,6 +119,7 @@ type (
 		IconSize   uint     `json:"iconSize"`
 		Enable     bool     `json:"enable"`
 		Query      string   `json:"query"`
+		Expr       string   `json:"expr"`
 		TextField  string   `json:"textField"`
 		TagsField  string   `json:"tagsField"`
 		Tags       []string `json:"tags"`

--- a/board.go
+++ b/board.go
@@ -111,20 +111,23 @@ type (
 		Value interface{} `json:"value"` // TODO select more precise type
 	}
 	Annotation struct {
-		Name       string   `json:"name"`
-		Datasource *string  `json:"datasource"`
-		ShowLine   bool     `json:"showLine"`
-		IconColor  string   `json:"iconColor"`
-		LineColor  string   `json:"lineColor"`
-		IconSize   uint     `json:"iconSize"`
-		Enable     bool     `json:"enable"`
-		Query      string   `json:"query"`
-		Expr       string   `json:"expr"`
-		Step       string   `json:"step"`
-		TextField  string   `json:"textField"`
-		TagsField  string   `json:"tagsField"`
-		Tags       []string `json:"tags"`
-		Type       string   `json:"type"`
+		Name        string   `json:"name"`
+		Datasource  *string  `json:"datasource"`
+		ShowLine    bool     `json:"showLine"`
+		IconColor   string   `json:"iconColor"`
+		LineColor   string   `json:"lineColor"`
+		IconSize    uint     `json:"iconSize"`
+		Enable      bool     `json:"enable"`
+		Query       string   `json:"query"`
+		Expr        string   `json:"expr"`
+		Step        string   `json:"step"`
+		TextField   string   `json:"textField"`
+		TextFormat  string   `json:"textFormat"`
+		TitleFormat string   `json:"titleFormat"`
+		TagsField   string   `json:"tagsField"`
+		Tags        []string `json:"tags"`
+		TagKeys     string   `json:"tagKeys"`
+		Type        string   `json:"type"`
 	}
 	// Link represents link to another dashboard or external weblink
 	Link struct {


### PR DESCRIPTION
Support fields used by Prometheus annotations on panels.

Usage example: https://github.com/sourcegraph/sourcegraph/pull/17198/files#diff-4132060621aa0b48b1ada84cd9c0fc0984c98250bfce3fe78d4f15eb5d8b39f6R79-R104