### PR TITLE
Add render as link options to ColumnStyles

### DIFF
--- a/panel.go
+++ b/panel.go
@@ -387,17 +387,21 @@ type (
 		Value    string `json:"value"`
 	}
 	ColumnStyle struct {
-		Alias       *string    `json:"alias"`
-		DateFormat  *string    `json:"dateFormat,omitempty"`
-		Pattern     string     `json:"pattern"`
-		Type        string     `json:"type"`
-		ColorMode   *string    `json:"colorMode,omitempty"`
-		Colors      *[]string  `json:"colors,omitempty"`
-		Decimals    *uint      `json:"decimals,omitempty"`
-		Thresholds  *[]string  `json:"thresholds,omitempty"`
-		Unit        *string    `json:"unit,omitempty"`
-		MappingType int        `json:"mappingType,omitempty"`
-		ValueMaps   []ValueMap `json:"valueMaps,omitempty"`
+		Alias           *string    `json:"alias"`
+		DateFormat      *string    `json:"dateFormat,omitempty"`
+		Pattern         string     `json:"pattern"`
+		Type            string     `json:"type"`
+		ColorMode       *string    `json:"colorMode,omitempty"`
+		Colors          *[]string  `json:"colors,omitempty"`
+		Decimals        *uint      `json:"decimals,omitempty"`
+		Thresholds      *[]string  `json:"thresholds,omitempty"`
+		Unit            *string    `json:"unit,omitempty"`
+		MappingType     int        `json:"mappingType,omitempty"`
+		ValueMaps       []ValueMap `json:"valueMaps,omitempty"`
+		Link            bool       `json:"link,omitempty"`
+		LinkTooltip     *string    `json:"linkTooltip,omitempty"`
+		LinkUrl         *string    `json:"linkUrl,omitempty"`
+		LinkTargetBlank bool       `json:"linkTargetBlank,omitempty"`
 	}
 )
 


### PR DESCRIPTION
This PR adds the missing properties that allows rendering cells as links in tables.  