### PR TITLE
board: use a more correct type for "Text"

### DIFF
--- a/board.go
+++ b/board.go
@@ -106,9 +106,9 @@ type (
 	}
 	// for templateVar
 	Current struct {
-		Tags  []*string   `json:"tags,omitempty"`
-		Text  interface{} `json:"text"`
-		Value interface{} `json:"value"` // TODO select more precise type
+		Tags  []*string          `json:"tags,omitempty"`
+		Text  *StringSliceString `json:"text"`
+		Value interface{}        `json:"value"` // TODO select more precise type
 	}
 	Annotation struct {
 		Name        string   `json:"name"`

--- a/custom-types.go
+++ b/custom-types.go
@@ -191,3 +191,45 @@ func (v *FloatString) MarshalJSON() ([]byte, error) {
 
 	return []byte(`"null"`), nil
 }
+
+// StringSliceString represents special type for json values that could be
+// strings or slice of strings: "something" or ["something"].
+type StringSliceString struct {
+	Value []string
+	Valid bool
+}
+
+// UnmarshalJSON implements custom unmarshalling for StringSliceString type.
+func (v *StringSliceString) UnmarshalJSON(raw []byte) error {
+	if raw == nil || bytes.Equal(raw, []byte(`"null"`)) {
+		return nil
+	}
+
+	// First try with string.
+	var str string
+	if err := json.Unmarshal(raw, &str); err == nil {
+		v.Value = []string{str}
+		v.Valid = true
+		return nil
+	}
+
+	// Lastly try with string slice.
+	var strSlice []string
+	err := json.Unmarshal(raw, &strSlice)
+	if err != nil {
+		return err
+	}
+
+	v.Value = strSlice
+	v.Valid = true
+	return nil
+}
+
+// MarshalJSON implements custom marshalling for StringSliceString type.
+func (v *StringSliceString) MarshalJSON() ([]byte, error) {
+	if !v.Valid {
+		return []byte(`"null"`), nil
+	}
+
+	return json.Marshal(v.Value)
+}

--- a/custom-types_test.go
+++ b/custom-types_test.go
@@ -22,6 +22,7 @@ package sdk_test
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/grafana-tools/sdk"
@@ -55,5 +56,138 @@ func TestIntString_Marshal(t *testing.T) {
 
 	if !bytes.Equal(body, []byte(`100`)) {
 		t.Error("Marshalled IntString is not valid: expected '100', got:", string(body))
+	}
+}
+
+func TestStringSliceString_Unmarshal(t *testing.T) {
+	tests := map[string]struct {
+		raw    string
+		exp    sdk.StringSliceString
+		expErr bool
+	}{
+		"Having an nil should unmarshall correctly as invalid.": {
+			raw: `"null"`,
+			exp: sdk.StringSliceString{
+				Valid: false,
+			},
+		},
+
+		"Having a string should unmarshall correctly.": {
+			raw: `"this is a test"`,
+			exp: sdk.StringSliceString{
+				Value: []string{"this is a test"},
+				Valid: true,
+			},
+		},
+
+		"Having a empty array should unmarshall correctly.": {
+			raw: `[]`,
+			exp: sdk.StringSliceString{
+				Value: []string{},
+				Valid: true,
+			},
+		},
+
+		"Having a single value array should unmarshall correctly.": {
+			raw: `["this is a test"]`,
+			exp: sdk.StringSliceString{
+				Value: []string{"this is a test"},
+				Valid: true,
+			},
+		},
+
+		"Having a multiple value array should unmarshall correctly.": {
+			raw: `["this", "is", "a", "test"]`,
+			exp: sdk.StringSliceString{
+				Value: []string{"this", "is", "a", "test"},
+				Valid: true,
+			},
+		},
+
+		"Having a wrong value should fail.": {
+			raw:    `[`,
+			expErr: true,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			var got sdk.StringSliceString
+
+			err := json.Unmarshal([]byte(test.raw), &got)
+
+			if test.expErr {
+				if err == nil {
+					t.Error("Expected error, got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Got unexpected error: %s", err)
+				}
+
+				if test.exp.Valid != got.Valid {
+					t.Errorf("Valid field is not valid, expected %t; got: %t", test.exp.Valid, got.Valid)
+				}
+
+				if fmt.Sprintf("%#v", test.exp.Value) != fmt.Sprintf("%#v", got.Value) {
+					t.Errorf("Value field is not valid, expected %#v; got: %#v", test.exp.Value, got.Value)
+				}
+			}
+		})
+	}
+}
+
+func TestStringSliceString_Marshall(t *testing.T) {
+	tests := map[string]struct {
+		value  *sdk.StringSliceString
+		exp    string
+		expErr bool
+	}{
+		"Having a single value should unmarshall correctly.": {
+			value: &sdk.StringSliceString{
+				Value: []string{"this is a test"},
+				Valid: true,
+			},
+			exp: `["this is a test"]`,
+		},
+
+		"Having an invalid value should return null.": {
+			value: &sdk.StringSliceString{},
+			exp:   `"null"`,
+		},
+
+		"Having a empty array should unmarshall correctly.": {
+			value: &sdk.StringSliceString{
+				Value: []string{},
+				Valid: true,
+			},
+			exp: `[]`,
+		},
+
+		"Having a multiple value array should unmarshall correctly.": {
+			value: &sdk.StringSliceString{
+				Value: []string{"this", "is", "a", "test"},
+				Valid: true,
+			},
+			exp: `["this","is","a","test"]`,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := json.Marshal(test.value)
+
+			if test.expErr {
+				if err == nil {
+					t.Error("Expected error, got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Got unexpected error: %s", err)
+				}
+
+				if test.exp != string(got) {
+					t.Errorf("Marshaled value is invalid, expected %s; got: %s", test.exp, string(got))
+				}
+			}
+		})
 	}
 }

--- a/testdata/empty-dashboard-with-templating-4.0.json
+++ b/testdata/empty-dashboard-with-templating-4.0.json
@@ -28,7 +28,7 @@
         "allValue": null,
         "current": {
           "tags": [],
-          "text": "one",
+          "text": ["one"],
           "value": "one"
         },
         "datasource": null,


### PR DESCRIPTION
Rebased changes from: https://github.com/grafana-tools/sdk/pull/110. Sorry for this but it is needed! Recently this has been changed to `interface{}`, now to a more strict type which does what we want.