### PR TITLE
org: Allow updating organization address

### DIFF
--- a/address.go
+++ b/address.go
@@ -1,0 +1,29 @@
+package sdk
+
+/*
+   Copyright 2016 Alexander I.Grafov <grafov@gmail.com>
+   Copyright 2016-2019 The Grafana SDK authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+	   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+   ॐ तारे तुत्तारे तुरे स्व
+*/
+
+type Address struct {
+	Address1 string `json:"address1"`
+	Address2 string `json:"address2"`
+	City     string `json:"city"`
+	ZipCode  string `json:"zipCode"`
+	State    string `json:"state"`
+	Country  string `json:"country"`
+}

--- a/org.go
+++ b/org.go
@@ -19,8 +19,9 @@ package sdk
 */
 
 type Org struct {
-	ID   uint   `json:"id"`
-	Name string `json:"name"`
+	ID      uint    `json:"id"`
+	Name    string  `json:"name"`
+	Address Address `json:"address"`
 }
 
 type OrgUser struct {

--- a/rest-org.go
+++ b/rest-org.go
@@ -394,3 +394,43 @@ func (r *Client) GetActualOrgPreferences(ctx context.Context) (Preferences, erro
 	}
 	return pref, err
 }
+
+// UpdateActualOrgAddress updates current organization's address.
+// It reflects PUT /api/org/address API call.
+func (r *Client) UpdateActualOrgAddress(ctx context.Context, address Address) (StatusMessage, error) {
+	var (
+		raw  []byte
+		resp StatusMessage
+		err  error
+	)
+	if raw, err = json.Marshal(address); err != nil {
+		return StatusMessage{}, err
+	}
+	if raw, _, err = r.put(ctx, "api/org/address", nil, raw); err != nil {
+		return StatusMessage{}, err
+	}
+	if err = json.Unmarshal(raw, &resp); err != nil {
+		return StatusMessage{}, err
+	}
+	return resp, nil
+}
+
+// UpdateOrgAddress updates the address of the organization identified by oid.
+// It reflects PUT /api/orgs/:orgId/address API call.
+func (r *Client) UpdateOrgAddress(ctx context.Context, address Address, oid uint) (StatusMessage, error) {
+	var (
+		raw  []byte
+		resp StatusMessage
+		err  error
+	)
+	if raw, err = json.Marshal(address); err != nil {
+		return StatusMessage{}, err
+	}
+	if raw, _, err = r.put(ctx, fmt.Sprintf("api/orgs/%d/address", oid), nil, raw); err != nil {
+		return StatusMessage{}, err
+	}
+	if err = json.Unmarshal(raw, &resp); err != nil {
+		return StatusMessage{}, err
+	}
+	return resp, nil
+}

--- a/rest-org_integration_test.go
+++ b/rest-org_integration_test.go
@@ -2,6 +2,7 @@ package sdk_test
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	"github.com/grafana-tools/sdk"
@@ -38,5 +39,80 @@ func TestCreateDelete(t *testing.T) {
 	_, err = client.GetOrgById(ctx, oID)
 	if err == nil {
 		t.Fatalf("org %s is still there even though it should be deleted", o.Name)
+	}
+}
+
+// TestUpdateOrgAddress checks if updating Org address works correctly
+func TestUpdateOrgAddress(t *testing.T) {
+	shouldSkip(t)
+
+	client := getClient(t)
+	ctx := context.Background()
+
+	// Create a new organization
+	oName := "coolorg"
+	o := sdk.Org{Name: oName}
+	statusMessage, err := client.CreateOrg(ctx, o)
+	if err != nil {
+		t.Fatalf("failed to create an org: %v (%s)", statusMessage, err.Error())
+	}
+	oID := *statusMessage.OrgID
+
+	// Test if updating organization by ID works as expected
+	// Create a dummy address object
+	address := sdk.Address{
+		Address1: "CoolAddress1",
+		Address2: "CoolAddress2",
+		City:     "CoolCity",
+		ZipCode:  "CoolZipCode",
+		State:    "CoolState",
+		Country:  "CoolCountry",
+	}
+
+	// Try updating organization address by Org ID
+	statusMessage, err = client.UpdateOrgAddress(ctx, address, oID)
+	if err != nil {
+		t.Fatalf("failed to update the address: %v (%s)", statusMessage, err.Error())
+	}
+
+	retrievedOrg, err := client.GetOrgById(ctx, oID)
+	if err != nil {
+		t.Fatalf("failed to retrieved org: %s", err.Error())
+	}
+
+	// Check if retrieved address values are equal to expected ones
+	if !reflect.DeepEqual(retrievedOrg.Address, address) {
+		t.Fatalf("got wrong address: got %+v, expected %+v", retrievedOrg.Address, address)
+	}
+
+	// Test if updating current organization works as expected
+	address = sdk.Address{
+		Address1: "NiceAddress1",
+		Address2: "NiceAddress2",
+		City:     "NiceCity",
+		ZipCode:  "NiceZipCode",
+		State:    "NiceState",
+		Country:  "NiceCountry",
+	}
+
+	statusMessage, err = client.SwitchActualUserContext(ctx, oID)
+	if err != nil {
+		t.Fatalf("failed to switch user context: %s", err.Error())
+	}
+
+	// Try updating current organization address
+	statusMessage, err = client.UpdateActualOrgAddress(ctx, address)
+	if err != nil {
+		t.Fatalf("failed to update the address: %v (%s)", statusMessage, err.Error())
+	}
+
+	retrievedOrg, err = client.GetActualOrg(ctx)
+	if err != nil {
+		t.Fatalf("failed to retrieved org: %s", err.Error())
+	}
+
+	// Check if retrieved address values are equal to expected ones
+	if !reflect.DeepEqual(retrievedOrg.Address, address) {
+		t.Fatalf("got wrong address: got %v, expected %v", retrievedOrg.Address, address)
 	}
 }


### PR DESCRIPTION
Adds a new method to allow updating the organization's address. 

While the Grafana documentation doesn't mention it, Grafana API actually supports it:)