### PR TITLE
Updating FieldConfig struct

### DIFF
--- a/panel.go
+++ b/panel.go
@@ -163,14 +163,22 @@ type (
 	}
 	FieldConfig struct {
 		Defaults struct {
-			Unit      string `json:"unit"`
-			Threshold struct {
+			DisplayName string `json:"displayName,omitempty"`
+			Unit        string `json:"unit"`
+			Threshold   struct {
 				Mode  string `json:"mode"`
 				Steps []struct {
 					Color string `json:"color"`
 					Value string `json:"value"`
 				} `json:"steps"`
 			} `json:"threshold"`
+			Thresholds struct {
+				Mode  string `json:"mode"`
+				Steps []struct {
+					Color string  `json:"color"`
+					Value float64 `json:"value"`
+				} `json:"steps"`
+			} `json:"thresholds"`
 		} `json:"defaults"`
 	}
 	Options struct {


### PR DESCRIPTION
Change-set:
* The grafana 7.X API looks for two new fields as part of the **FieldConfig** struct; **displayName** and **thresholds**
