### PR TITLE
Use generic interface{} instead of string for TemplateVar.templating.…

### DIFF
--- a/board.go
+++ b/board.go
@@ -79,24 +79,24 @@ type (
 		List []TemplateVar `json:"list"`
 	}
 	TemplateVar struct {
-		Name        string   `json:"name"`
-		Type        string   `json:"type"`
-		Auto        bool     `json:"auto,omitempty"`
-		AutoCount   *int     `json:"auto_count,omitempty"`
-		Datasource  *string  `json:"datasource"`
-		Refresh     BoolInt  `json:"refresh"`
-		Options     []Option `json:"options"`
-		IncludeAll  bool     `json:"includeAll"`
-		AllFormat   string   `json:"allFormat"`
-		AllValue    string   `json:"allValue"`
-		Multi       bool     `json:"multi"`
-		MultiFormat string   `json:"multiFormat"`
-		Query       string   `json:"query"`
-		Regex       string   `json:"regex"`
-		Current     Current  `json:"current"`
-		Label       string   `json:"label"`
-		Hide        uint8    `json:"hide"`
-		Sort        int      `json:"sort"`
+		Name        string      `json:"name"`
+		Type        string      `json:"type"`
+		Auto        bool        `json:"auto,omitempty"`
+		AutoCount   *int        `json:"auto_count,omitempty"`
+		Datasource  *string     `json:"datasource"`
+		Refresh     BoolInt     `json:"refresh"`
+		Options     []Option    `json:"options"`
+		IncludeAll  bool        `json:"includeAll"`
+		AllFormat   string      `json:"allFormat"`
+		AllValue    string      `json:"allValue"`
+		Multi       bool        `json:"multi"`
+		MultiFormat string      `json:"multiFormat"`
+		Query       interface{} `json:"query"`
+		Regex       string      `json:"regex"`
+		Current     Current     `json:"current"`
+		Label       string      `json:"label"`
+		Hide        uint8       `json:"hide"`
+		Sort        int         `json:"sort"`
 	}
 	// for templateVar
 	Option struct {


### PR DESCRIPTION
Use generic `interface{}` instead of `string` for `TemplateVar.templating.list.query`

The return type appears to vary depending on the `Datasource` and I could not track down a schema defining this type.

Fixes https://github.com/grafana-tools/sdk/issues/130 (the `Board.panels` unmarshal was fixed by https://github.com/grafana-tools/sdk/pull/141)