### PR TITLE
Fix Decimals type

### DIFF
--- a/panel.go
+++ b/panel.go
@@ -133,7 +133,7 @@ type (
 		Bars        bool        `json:"bars"`
 		DashLength  *uint       `json:"dashLength,omitempty"`
 		Dashes      *bool       `json:"dashes,omitempty"`
-		Decimals    *uint       `json:"decimals,omitempty"`
+		Decimals    *int       `json:"decimals,omitempty"`
 		Fill        int         `json:"fill"`
 		//		Grid        grid        `json:"grid"` obsoleted in 4.1 by xaxis and yaxis
 
@@ -442,7 +442,7 @@ type (
 		Type            string     `json:"type"`
 		ColorMode       *string    `json:"colorMode,omitempty"`
 		Colors          *[]string  `json:"colors,omitempty"`
-		Decimals        *uint      `json:"decimals,omitempty"`
+		Decimals        *int      `json:"decimals,omitempty"`
 		Thresholds      *[]string  `json:"thresholds,omitempty"`
 		Unit            *string    `json:"unit,omitempty"`
 		MappingType     int        `json:"mappingType,omitempty"`


### PR DESCRIPTION
See https://gist.github.com/hjet/8e0f8fc9b3cfb2de23fb1e7eb9825bb7 for a dashboard that breaks upon deserializing

This PR fixes the type for `GraphPanel.Decimals` and `ColumnStyle.Decimals`