### PR TITLE
add resultFormat field to Target

### DIFF
--- a/panel.go
+++ b/panel.go
@@ -133,7 +133,7 @@ type (
 		Bars        bool        `json:"bars"`
 		DashLength  *uint       `json:"dashLength,omitempty"`
 		Dashes      *bool       `json:"dashes,omitempty"`
-		Decimals    *int       `json:"decimals,omitempty"`
+		Decimals    *int        `json:"decimals,omitempty"`
 		Fill        int         `json:"fill"`
 		//		Grid        grid        `json:"grid"` obsoleted in 4.1 by xaxis and yaxis
 
@@ -442,7 +442,7 @@ type (
 		Type            string     `json:"type"`
 		ColorMode       *string    `json:"colorMode,omitempty"`
 		Colors          *[]string  `json:"colors,omitempty"`
-		Decimals        *int      `json:"decimals,omitempty"`
+		Decimals        *int       `json:"decimals,omitempty"`
 		Thresholds      *[]string  `json:"thresholds,omitempty"`
 		Unit            *string    `json:"unit,omitempty"`
 		MappingType     int        `json:"mappingType,omitempty"`
@@ -514,7 +514,8 @@ type Target struct {
 	Format         string `json:"format,omitempty"`
 
 	// For InfluxDB
-	Measurement string `json:"measurement,omitempty"`
+	Measurement  string `json:"measurement,omitempty"`
+	ResultFormat string `json:"resultFormat,omitempty"`
 
 	// For Elasticsearch
 	DsType  *string `json:"dsType,omitempty"`


### PR DESCRIPTION
I’m using the SDK to manage dashboards and alerts as code.  I hit an issue trying to create alerts based on InfluxDB raw query targets.  When testing the alert in grafana I see this error message:

```
request handler error: failed to query data: type assertion to string failed
```

The grafana code [here](https://github.com/grafana/grafana/blob/main/pkg/tsdb/influxdb/model_parser.go#L23) seems to require that the `resultFormat` JSON field must be present.

I tested the change in the PR locally (by adding `ResultFormat: "time_series"` to my Target definition) and the alert performs as expected without the error message.

Let me know if you need any more details, Thanks.