### PR TITLE
Add Target.Tags (#169)

### DIFF
--- a/panel.go
+++ b/panel.go
@@ -567,6 +567,11 @@ type Target struct {
 	PerSeriesAligner   string                    `json:"perSeriesAligner,omitempty"`
 	ValueType          string                    `json:"valueType,omitempty"`
 	GroupBys           []string                  `json:"groupBys,omitempty"`
+	Tags               []struct {
+		Key      string `json:key,omitempty`
+		Operator string `json:key,omitempty`
+		Value    string `json:key,omitempty`
+	}
 }
 
 // StackdriverAlignOptions defines the list of alignment options shown in


### PR DESCRIPTION
<img width="255" alt="Screenshot 2021-09-29 at 14 31 42" src="https://user-images.githubusercontent.com/2488613/135328078-9ead736e-c42a-4de4-93cc-2345bf3e053e.png">

in the Panel JSON inspector, Target objects have a Tags field which are used to filter and sort data in the time series graph. This adds that field to the Target object in the SDK.