### PR TITLE
🐛: Target.GroupBy should be singular in the type declaration

### DIFF
--- a/panel.go
+++ b/panel.go
@@ -566,7 +566,7 @@ type Target struct {
 	CrossSeriesReducer string                    `json:"crossSeriesReducer,omitempty"`
 	PerSeriesAligner   string                    `json:"perSeriesAligner,omitempty"`
 	ValueType          string                    `json:"valueType,omitempty"`
-	GroupBys           []string                  `json:"groupBys,omitempty"`
+	GroupBy            []string                  `json:"groupBys,omitempty"`
 	Tags               []struct {
 		Key      string `json:"key,omitempty"`
 		Operator string `json:"operator,omitempty"`

--- a/panel.go
+++ b/panel.go
@@ -566,7 +566,7 @@ type Target struct {
 	CrossSeriesReducer string                    `json:"crossSeriesReducer,omitempty"`
 	PerSeriesAligner   string                    `json:"perSeriesAligner,omitempty"`
 	ValueType          string                    `json:"valueType,omitempty"`
-	GroupBy            []string                  `json:"groupBys,omitempty"`
+	GroupBy            []string                  `json:"groupBy,omitempty"`
 	Tags               []struct {
 		Key      string `json:"key,omitempty"`
 		Operator string `json:"operator,omitempty"`

--- a/panel_test.go
+++ b/panel_test.go
@@ -630,7 +630,7 @@ func TestPanel_Stackdriver_ParsedTargets(t *testing.T) {
 		"=",
 		"some_subscription_id"
 	  ],
-	  "groupBys": [],
+	  "groupBy": [],
 	  "metricKind": "DELTA",
 	  "metricType": "pubsub.googleapis.com/subscription/ack_message_count",
 	  "perSeriesAligner": "ALIGN_DELTA",


### PR DESCRIPTION
in Grafana 8.0.5:

Before, I was using the `Target.GroupBys` property, but it turns out that that did not have any effect. By examining other dashboards manually created, I noticed that the JSON for the Panels actually had `groupby` in the singular. By changing the panel json for panels created by the grafana sdk and applying it, I was able to get the desired functionality.

With the plural:
<img width="316" alt="Screenshot 2021-10-28 at 16 53 00" src="https://user-images.githubusercontent.com/2488613/139334280-f7fc957b-1db5-4a68-b720-5ad319d4113c.png"><img width="294" alt="Screenshot 2021-10-28 at 16 53 13" src="https://user-images.githubusercontent.com/2488613/139334296-ca25774e-9b1f-448c-afa8-379e3f37fa2b.png">

and with the singular:

<img width="313" alt="Screenshot 2021-10-28 at 16 53 46" src="https://user-images.githubusercontent.com/2488613/139334311-16c9e216-67e4-4c39-8265-5e1a4285871e.png"><img width="269" alt="Screenshot 2021-10-28 at 16 53 31" src="https://user-images.githubusercontent.com/2488613/139334318-752e7af2-d41d-4a07-a4c4-c107139896e0.png">

the name of the cluster is redacted because it does display correctly.

this should restore the groupby functionality in the grafana-sdk. I did a search to see if the `GroupBys` property was ever used, and I don't see any evidence of it in the documentation.
 