### PR TITLE
Support a datasource which may be a map

### DIFF
--- a/board.go
+++ b/board.go
@@ -83,7 +83,7 @@ type (
 		Type        string      `json:"type"`
 		Auto        bool        `json:"auto,omitempty"`
 		AutoCount   *int        `json:"auto_count,omitempty"`
-		Datasource  *string     `json:"datasource"`
+		Datasource  interface{} `json:"datasource"`
 		Refresh     BoolInt     `json:"refresh"`
 		Options     []Option    `json:"options"`
 		IncludeAll  bool        `json:"includeAll"`
@@ -111,23 +111,23 @@ type (
 		Value interface{}        `json:"value"` // TODO select more precise type
 	}
 	Annotation struct {
-		Name        string   `json:"name"`
-		Datasource  *string  `json:"datasource"`
-		ShowLine    bool     `json:"showLine"`
-		IconColor   string   `json:"iconColor"`
-		LineColor   string   `json:"lineColor"`
-		IconSize    uint     `json:"iconSize"`
-		Enable      bool     `json:"enable"`
-		Query       string   `json:"query"`
-		Expr        string   `json:"expr"`
-		Step        string   `json:"step"`
-		TextField   string   `json:"textField"`
-		TextFormat  string   `json:"textFormat"`
-		TitleFormat string   `json:"titleFormat"`
-		TagsField   string   `json:"tagsField"`
-		Tags        []string `json:"tags"`
-		TagKeys     string   `json:"tagKeys"`
-		Type        string   `json:"type"`
+		Name        string      `json:"name"`
+		Datasource  interface{} `json:"datasource"`
+		ShowLine    bool        `json:"showLine"`
+		IconColor   string      `json:"iconColor"`
+		LineColor   string      `json:"lineColor"`
+		IconSize    uint        `json:"iconSize"`
+		Enable      bool        `json:"enable"`
+		Query       string      `json:"query"`
+		Expr        string      `json:"expr"`
+		Step        string      `json:"step"`
+		TextField   string      `json:"textField"`
+		TextFormat  string      `json:"textFormat"`
+		TitleFormat string      `json:"titleFormat"`
+		TagsField   string      `json:"tagsField"`
+		Tags        []string    `json:"tags"`
+		TagKeys     string      `json:"tagKeys"`
+		Type        string      `json:"type"`
 	}
 	// Link represents link to another dashboard or external weblink
 	Link struct {

--- a/dashboard-unmarshal_test.go
+++ b/dashboard-unmarshal_test.go
@@ -101,8 +101,8 @@ func TestUnmarshal_DashboardWithGraphWithTargets26(t *testing.T) {
 	if panel.OfType != sdk.GraphType {
 		t.Errorf("panel type should be %d (\"graph\") type but got %d", sdk.GraphType, panel.OfType)
 	}
-	if *panel.Datasource != sdk.MixedSource {
-		t.Errorf("panel Datasource should be \"%s\" but got \"%s\"", sdk.MixedSource, *panel.Datasource)
+	if panel.Datasource != sdk.MixedSource {
+		t.Errorf("panel Datasource should be \"%s\" but got \"%s\"", sdk.MixedSource, panel.Datasource)
 	}
 	if len(panel.GraphPanel.Targets) != 2 {
 		t.Errorf("panel has 2 targets but got %d", len(panel.GraphPanel.Targets))
@@ -187,4 +187,41 @@ func TestUnmarshal_DashboardWithMixedYaxes(t *testing.T) {
 	if max4.Value != 50 || max4.Valid != true {
 		t.Errorf("panel #1 has wrong max value: %f, expected: %f", max4.Value, 100.0)
 	}
+}
+
+func TestUnmarshal_DashboardWithGraphWithTargets83(t *testing.T) {
+	var board sdk.Board
+	raw, _ := ioutil.ReadFile("testdata/default-panels-graph-with-target-8.3.json")
+
+	err := json.Unmarshal(raw, &board)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(board.Panels) != 2 {
+		t.Fatalf("board should have 2 panels but got %d", len(board.Panels))
+	}
+	rowPanel := board.Panels[0]
+	if rowPanel.OfType != sdk.RowType {
+		t.Errorf("panel type should be %d (\"row\") type but got %d", sdk.GraphType, rowPanel.OfType)
+	}
+
+	panel := board.Panels[1]
+	if panel.OfType != sdk.GraphType {
+		t.Errorf("panel type should be %d (\"graph\") type but got %d", sdk.GraphType, panel.OfType)
+	}
+
+	if len(panel.GraphPanel.Targets) != 1 {
+		t.Errorf("panel has 1 targets but got %d", len(panel.GraphPanel.Targets))
+	}
+
+	target := panel.GraphPanel.Targets[0]
+	datasource, ok := target.Datasource.(map[string]interface{})
+	if !ok {
+		t.Fatalf("target Datasource should be a map but got %T", panel.Datasource)
+	}
+	if datasource["type"] != "prometheus" {
+		t.Errorf("target datasource should be of type \"prometheus\" but got %s", datasource["type"])
+	}
+
 }

--- a/panel.go
+++ b/panel.go
@@ -64,9 +64,9 @@ type (
 	}
 	panelType   int8
 	CommonPanel struct {
-		Datasource *string `json:"datasource,omitempty"` // metrics
-		Editable   bool    `json:"editable"`
-		Error      bool    `json:"error"`
+		Datasource interface{} `json:"datasource,omitempty"` // metrics
+		Editable   bool        `json:"editable"`
+		Error      bool        `json:"error"`
 		GridPos    struct {
 			H *int `json:"h,omitempty"`
 			W *int `json:"w,omitempty"`
@@ -483,9 +483,9 @@ type (
 
 // for an any panel
 type Target struct {
-	RefID      string `json:"refId"`
-	Datasource string `json:"datasource,omitempty"`
-	Hide       bool   `json:"hide,omitempty"`
+	RefID      string      `json:"refId"`
+	Datasource interface{} `json:"datasource,omitempty"`
+	Hide       bool        `json:"hide,omitempty"`
 
 	// For PostgreSQL
 	Table        string `json:"table,omitempty"`

--- a/testdata/default-panels-graph-with-target-8.3.json
+++ b/testdata/default-panels-graph-with-target-8.3.json
@@ -1,0 +1,138 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 12,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 4,
+      "title": "Basic Row",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "hiddenSeries": false,
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.3.2",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Ilg0cn17k"
+          },
+          "exemplar": true,
+          "expr": "go_goroutines{job=\"prometheus\"}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Panel Title",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    }
+  ],
+  "schemaVersion": 33,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Basic Dashboard",
+  "uid": "t5LxFe17z",
+  "version": 4,
+  "weekStart": ""
+}


### PR DESCRIPTION
In recent versions of Grafana the datasource can be either a string or a
map with entries for type and uid. Support both of these cases by using
an interface which will allow backwards compatiblity.

Alternatively, I could change Datasource to a more concrete type that
can marshal/unmarshal from a string or map, but that would break anyone
just setting it to a string right now. Let me know what you think!

See https://github.com/grafana/grafana/pull/33817 for more context on the
change in Grafana.