### PR TITLE
feat: dashboard versions API support

### DIFF
--- a/rest-dashboard.go
+++ b/rest-dashboard.go
@@ -129,14 +129,14 @@ type DashboardVersion struct {
 }
 
 // GetDashboardVersionsByDashboardID reflects /api/dashboards/id/:dashboardId/versions API call
-func (r *Client) GetDashboardVersionsByDashboardID(ctx context.Context, id uint, params ...QueryParam) ([]DashboardVersion, error) {
+func (r *Client) GetDashboardVersionsByDashboardID(ctx context.Context, dashboardID uint, params ...QueryParam) ([]DashboardVersion, error) {
 	var (
 		raw  []byte
 		code int
 		err  error
 	)
 
-	if raw, code, err = r.get(ctx, fmt.Sprintf("api/dashboards/id/%d/versions", id), queryParams(params...)); err != nil {
+	if raw, code, err = r.get(ctx, fmt.Sprintf("api/dashboards/id/%d/versions", dashboardID), queryParams(params...)); err != nil {
 		return nil, err
 	}
 	if code != 200 {

--- a/rest-dashboard.go
+++ b/rest-dashboard.go
@@ -116,6 +116,42 @@ func (r *Client) GetDashboardBySlug(ctx context.Context, slug string) (Board, Bo
 	return r.getDashboard(ctx, path)
 }
 
+// DashboardVersion represents a response from /api/dashboards/id/:dashboardId/versions API
+type DashboardVersion struct {
+	ID            int       `json:"id"`
+	DashboardID   int       `json:"dashboardId"`
+	ParentVersion int       `json:"parentVersion"`
+	RestoredFrom  int       `json:"restoredFrom"`
+	Version       int       `json:"version"`
+	Created       time.Time `json:"created"`
+	CreatedBy     string    `json:"createdBy"`
+	Message       string    `json:"message"`
+}
+
+// GetDashboardVersionsByID reflects /api/dashboards/id/:dashboardId/versions API call
+func (r *Client) GetDashboardVersionsByID(ctx context.Context, id uint, start, limit int) ([]DashboardVersion, error) {
+	var (
+		raw    []byte
+		code   int
+		err    error
+		params = url.Values{
+			"start": []string{strconv.Itoa(start)},
+			"limit": []string{strconv.Itoa(limit)},
+		}
+	)
+
+	if raw, code, err = r.get(ctx, fmt.Sprintf("api/dashboards/id/%d/versions", id), params); err != nil {
+		return nil, err
+	}
+	if code != 200 {
+		return nil, fmt.Errorf("HTTP error %d: returns %s", code, raw)
+	}
+	var versions []DashboardVersion
+	err = json.Unmarshal(raw, &versions)
+
+	return versions, err
+}
+
 // getDashboard loads a dashboard from Grafana instance along with metadata for a dashboard.
 // For dashboards from a filesystem set "file/" prefix for slug. By default dashboards from
 // a database assumed. Database dashboards may have "db/" prefix or may have not, it will

--- a/rest-dashboard_integration_test.go
+++ b/rest-dashboard_integration_test.go
@@ -116,3 +116,69 @@ func Test_Dashboard_CRUD_By_UID(t *testing.T) {
 	}
 
 }
+
+func Test_GetDashboardVersionsByDashboardID(t *testing.T) {
+	var (
+		board sdk.Board
+		err   error
+		start = sdk.QueryParamStart(0)
+		limit = sdk.QueryParamLimit(10)
+	)
+	ctx := context.Background()
+	client := getClient(t)
+	raw, _ := ioutil.ReadFile("testdata/new-empty-dashboard-2.6.json")
+
+	if err = json.Unmarshal(raw, &board); err != nil {
+		t.Fatal(err)
+	}
+	board.UID = "1234"
+	if _, err = client.DeleteDashboardByUID(ctx, board.UID); err != nil {
+		t.Fatal(err)
+	}
+
+	params := sdk.SetDashboardParams{
+		FolderID:  sdk.DefaultFolderId,
+		Overwrite: false,
+	}
+	// create initial dashboard
+	if _, err = client.SetDashboard(ctx, board, params); err != nil {
+		t.Fatal(err)
+	}
+
+	board, _, err = client.GetDashboardByUID(ctx, board.UID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// update dashboard to create a new version
+	params.Overwrite = true
+	if _, err = client.SetDashboard(ctx, board, params); err != nil {
+		t.Fatal(err)
+	}
+	board, _, err = client.GetDashboardByUID(ctx, board.UID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// fetch versions
+	versions, err := client.GetDashboardVersionsByDashboardID(ctx, board.ID, start, limit)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// we should have 2 versions
+	if len(versions) != 2 {
+		t.Fatal("dashboard should have 2 versions")
+	}
+	// the latest version in Grafana should match the current version of the board
+	// API returns versions sorted DESC
+	if versions[0].Version != board.Version {
+		t.Fatal("dashboard version from dashboards/uid/:uid API does not match latest dashboard version from dashboards/id/:dashboardId/versions API")
+	}
+
+	// fetch non-existing dashboard to validate error case
+	_, err = client.GetDashboardVersionsByDashboardID(ctx, 42, start, limit)
+	if err == nil {
+		t.Fatal("when fetching dashboard version with erroneous inputs, it should return an error, got nil error")
+	}
+}


### PR DESCRIPTION
I needed to query this API with Golang and realized I could not with this SDK.

So I created a method to be able to query it following https://grafana.com/docs/grafana/latest/http_api/dashboard_versions/