### PR TITLE
Added folder permission REST support

### DIFF
--- a/folder-permissions.go
+++ b/folder-permissions.go
@@ -44,25 +44,3 @@ type FolderPermission struct {
 	IsFolder       bool           `json:"isFolder"`
 	Url            string         `json:"url,omitempty"`
 }
-
-// UpdateFolderPermissionRequest is a request to update the folder permissions
-type UpdateFolderPermissionRequest struct {
-	Permission PermissionType `json:"permission"`
-	UserId     uint           `json:"userId,omitempty"`
-	TeamId     uint           `json:"teamId,omitempty"`
-	Role       string         `json:"role,omitempty"`
-}
-
-// MapFolderPermissionsToUpdateRequest maps FolderPermission structs to UpdateFolderPermissionRequest
-func MapFolderPermissionsToUpdateRequest(permissions []FolderPermission) []UpdateFolderPermissionRequest {
-	var updates []UpdateFolderPermissionRequest
-	for _, permission := range permissions {
-		updates = append(updates, UpdateFolderPermissionRequest{
-			Permission: permission.Permission,
-			UserId:     permission.UserId,
-			TeamId:     permission.TeamId,
-			Role:       permission.Role,
-		})
-	}
-	return updates
-}

--- a/folder-permissions.go
+++ b/folder-permissions.go
@@ -1,0 +1,68 @@
+package sdk
+
+/*
+   Copyright 2016 Alexander I.Grafov <grafov@gmail.com>
+   Copyright 2016-2022 The Grafana SDK authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+	   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+   ॐ तारे तुत्तारे तुरे स्व
+*/
+
+type PermissionType uint
+
+const PermissionView = PermissionType(1)
+const PermissionEdit = PermissionType(2)
+const PermissionAdmin = PermissionType(4)
+
+type FolderPermission struct {
+	Id             uint           `json:"id"`
+	FolderId       uint           `json:"folderId"`
+	Created        string         `json:"created"`
+	Updated        string         `json:"updated"`
+	UserId         uint           `json:"userId,omitempty"`
+	UserLogin      string         `json:"userLogin,omitempty"`
+	UserEmail      string         `json:"userEmail,omitempty"`
+	TeamId         uint           `json:"teamId,omitempty"`
+	Team           string         `json:"team,omitempty"`
+	Role           string         `json:"role,omitempty"`
+	Permission     PermissionType `json:"permission"`
+	PermissionName string         `json:"permissionName"`
+	Uid            string         `json:"uid,omitempty"`
+	Title          string         `json:"title,omitempty"`
+	Slug           string         `json:"slug,omitempty"`
+	IsFolder       bool           `json:"isFolder"`
+	Url            string         `json:"url,omitempty"`
+}
+
+// UpdateFolderPermissionRequest is a request to update the folder permissions
+type UpdateFolderPermissionRequest struct {
+	Permission PermissionType `json:"permission"`
+	UserId     uint           `json:"userId,omitempty"`
+	TeamId     uint           `json:"teamId,omitempty"`
+	Role       string         `json:"role,omitempty"`
+}
+
+// MapFolderPermissionsToUpdateRequest maps FolderPermission structs to UpdateFolderPermissionRequest
+func MapFolderPermissionsToUpdateRequest(permissions []FolderPermission) []UpdateFolderPermissionRequest {
+	var updates []UpdateFolderPermissionRequest
+	for _, permission := range permissions {
+		updates = append(updates, UpdateFolderPermissionRequest{
+			Permission: permission.Permission,
+			UserId:     permission.UserId,
+			TeamId:     permission.TeamId,
+			Role:       permission.Role,
+		})
+	}
+	return updates
+}

--- a/rest-folder-permissions.go
+++ b/rest-folder-permissions.go
@@ -1,0 +1,74 @@
+package sdk
+
+/*
+   Copyright 2016 Alexander I.Grafov <grafov@gmail.com>
+   Copyright 2016-2022 The Grafana SDK authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+	   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+   ॐ तारे तुत्तारे तुरे स्व
+*/
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// https://grafana.com/docs/grafana/latest/http_api/folder_permissions/
+
+// GetFolderPermissions gets permissions for a folder.
+// Reflects GET /api/folders/:uid/permissions API call.
+func (r *Client) GetFolderPermissions(ctx context.Context, folderUID string) ([]FolderPermission, error) {
+	var (
+		raw           []byte
+		fs            []FolderPermission
+		code          int
+		err           error
+	)
+	if raw, code, err = r.get(ctx, fmt.Sprintf("api/folders/%s/permissions", folderUID), nil); err != nil {
+		return nil, err
+	}
+	if code != 200 {
+		return nil, fmt.Errorf("HTTP error %d: returns %s", code, raw)
+	}
+	err = json.Unmarshal(raw, &fs)
+	return fs, err
+}
+
+// UpdateFolderPermissions update folders permission
+// Reflects PUT /api/folders/:uid/permissions API call.
+func (r *Client) UpdateFolderPermissions(ctx context.Context, folderUID string, up ...UpdateFolderPermissionRequest) (StatusMessage, error) {
+	var (
+		raw  []byte
+		rf   StatusMessage
+		code int
+		err  error
+	)
+	request := struct {
+		Items []UpdateFolderPermissionRequest `json:"items"`
+	}{
+		Items: up,
+	}
+	if raw, err = json.Marshal(request); err != nil {
+		return rf, err
+	}
+	if raw, code, err = r.post(ctx, fmt.Sprintf("api/folders/%s/permissions", folderUID), nil, raw); err != nil {
+		return rf, err
+	}
+	if code != 200 {
+		return rf, fmt.Errorf("HTTP error %d: returns %s", code, raw)
+	}
+	err = json.Unmarshal(raw, &rf)
+	return rf, err
+}

--- a/rest-folder-permissions.go
+++ b/rest-folder-permissions.go
@@ -31,10 +31,10 @@ import (
 // Reflects GET /api/folders/:uid/permissions API call.
 func (r *Client) GetFolderPermissions(ctx context.Context, folderUID string) ([]FolderPermission, error) {
 	var (
-		raw           []byte
-		fs            []FolderPermission
-		code          int
-		err           error
+		raw  []byte
+		fs   []FolderPermission
+		code int
+		err  error
 	)
 	if raw, code, err = r.get(ctx, fmt.Sprintf("api/folders/%s/permissions", folderUID), nil); err != nil {
 		return nil, err
@@ -48,7 +48,7 @@ func (r *Client) GetFolderPermissions(ctx context.Context, folderUID string) ([]
 
 // UpdateFolderPermissions update folders permission
 // Reflects PUT /api/folders/:uid/permissions API call.
-func (r *Client) UpdateFolderPermissions(ctx context.Context, folderUID string, up ...UpdateFolderPermissionRequest) (StatusMessage, error) {
+func (r *Client) UpdateFolderPermissions(ctx context.Context, folderUID string, up ...FolderPermission) (StatusMessage, error) {
 	var (
 		raw  []byte
 		rf   StatusMessage
@@ -56,7 +56,7 @@ func (r *Client) UpdateFolderPermissions(ctx context.Context, folderUID string, 
 		err  error
 	)
 	request := struct {
-		Items []UpdateFolderPermissionRequest `json:"items"`
+		Items []FolderPermission `json:"items"`
 	}{
 		Items: up,
 	}

--- a/rest-folder-permissions_integration_test.go
+++ b/rest-folder-permissions_integration_test.go
@@ -38,14 +38,14 @@ func Test_FolderPermissions(t *testing.T) {
 		t.Fatalf("failed to get actual user: %s", err.Error())
 	}
 
-	var updatePermissions []sdk.UpdateFolderPermissionRequest
-	updatePermissions = append(updatePermissions, sdk.MapFolderPermissionsToUpdateRequest(permissions)...)
-	updatePermissions = append(updatePermissions, sdk.UpdateFolderPermissionRequest{
+	var updatePermissions []sdk.FolderPermission
+	updatePermissions = append(updatePermissions, permissions...)
+	updatePermissions = append(updatePermissions, sdk.FolderPermission{
 		Permission: sdk.PermissionAdmin,
-		UserId: actualUser.ID,
+		UserId:     actualUser.ID,
 	})
 
-	_ , err = client.UpdateFolderPermissions(ctx, folder.UID,
+	_, err = client.UpdateFolderPermissions(ctx, folder.UID,
 		updatePermissions...,
 	)
 	if err != nil {

--- a/rest-folder-permissions_integration_test.go
+++ b/rest-folder-permissions_integration_test.go
@@ -22,7 +22,9 @@ func Test_FolderPermissions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer client.DeleteFolderByUID(ctx, folder.UID)
+	defer func(client *sdk.Client, ctx context.Context, UID string) {
+		_, _ = client.DeleteFolderByUID(ctx, UID)
+	}(client, ctx, folder.UID)
 
 	permissions, err := client.GetFolderPermissions(ctx, folder.UID)
 	if err != nil {

--- a/rest-folder-permissions_integration_test.go
+++ b/rest-folder-permissions_integration_test.go
@@ -1,0 +1,63 @@
+package sdk_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/grafana-tools/sdk"
+)
+
+func Test_FolderPermissions(t *testing.T) {
+	shouldSkip(t)
+
+	client := getClient(t)
+	ctx := context.Background()
+
+	var f = sdk.Folder{
+		Title: "test-permissions-folder",
+	}
+	var err error
+
+	folder, err := client.CreateFolder(ctx, f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.DeleteFolderByUID(ctx, folder.UID)
+
+	permissions, err := client.GetFolderPermissions(ctx, folder.UID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defaultPermissionCount := len(permissions)
+	if defaultPermissionCount == 0 {
+		t.Fatalf("Expected default permission count to be zero but was %d", defaultPermissionCount)
+	}
+
+	actualUser, err := client.GetActualUser(ctx)
+	if err != nil {
+		t.Fatalf("failed to get actual user: %s", err.Error())
+	}
+
+	var updatePermissions []sdk.UpdateFolderPermissionRequest
+	updatePermissions = append(updatePermissions, sdk.MapFolderPermissionsToUpdateRequest(permissions)...)
+	updatePermissions = append(updatePermissions, sdk.UpdateFolderPermissionRequest{
+		Permission: sdk.PermissionAdmin,
+		UserId: actualUser.ID,
+	})
+
+	_ , err = client.UpdateFolderPermissions(ctx, folder.UID,
+		updatePermissions...,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	updatedPermissions, err := client.GetFolderPermissions(ctx, folder.UID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	updatedPermissionCount := len(updatedPermissions)
+	if (defaultPermissionCount + 1) != updatedPermissionCount {
+		t.Fatal("Expected permissions count to increase by 1")
+	}
+}


### PR DESCRIPTION
Added support for folder permissions according to the documentation:
[https://grafana.com/docs/grafana/latest/http_api/folder_permissions/](https://grafana.com/docs/grafana/latest/http_api/folder_permissions/)