### PR TITLE
Threshold value as a number

### DIFF
--- a/panel.go
+++ b/panel.go
@@ -373,8 +373,8 @@ type (
 	FieldConfigDefaults struct {
 		Unit       string            `json:"unit"`
 		Decimals   *int              `json:"decimals,omitempty"`
-		Min        *int              `json:"min,omitempty"`
-		Max        *int              `json:"max,omitempty"`
+		Min        *float64          `json:"min,omitempty"`
+		Max        *float64          `json:"max,omitempty"`
 		Color      FieldConfigColor  `json:"color"`
 		Thresholds Thresholds        `json:"thresholds"`
 		Custom     FieldConfigCustom `json:"custom"`
@@ -419,8 +419,8 @@ type (
 		Steps []ThresholdStep `json:"steps"`
 	}
 	ThresholdStep struct {
-		Color string `json:"color"`
-		Value *int   `json:"value"`
+		Color string   `json:"color"`
+		Value *float64 `json:"value"`
 	}
 	FieldConfigColor struct {
 		Mode       string `json:"mode"`


### PR DESCRIPTION
Threshold value is defined as a number in Grafana:

http://github.com/grafana/grafana/blob/dd2a952c29db6d190dacdd6c06dd748f7912db9e/packages/grafana-data/src/types/thresholds.ts#L2-L2

I was tempted to use a json.Number for this, but apparently the convention is to just use floats, so I went for that.

Signed-off-by: Oleg Zaytsev <mail@olegzaytsev.com>