### PR TITLE
Match grafana ver

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rainycape/unidecode v0.0.0-20150907023854-cb7f23ec59be h1:ta7tUOvsPHVHGom5hKW5VXNc2xZIkfCKP8iaqOyYtUQ=
 github.com/rainycape/unidecode v0.0.0-20150907023854-cb7f23ec59be/go.mod h1:MIDFMn7db1kT65GmV94GzpX9Qdi7N/pQlwb+AN8wh+Q=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/panel.go
+++ b/panel.go
@@ -548,10 +548,15 @@ type (
 	}
 )
 
+type DataSource struct {
+   Type string `json:"type,omitempty"` 
+   Uid  string `json:"uid,omitempty"` 
+}
+
 // for an any panel
 type Target struct {
 	RefID      string `json:"refId"`
-	Datasource string `json:"datasource,omitempty"`
+	Datasource DataSource `json:"datasource,omitempty"`
 	Hide       bool   `json:"hide,omitempty"`
 
 	// For PostgreSQL

--- a/panel.go
+++ b/panel.go
@@ -166,8 +166,10 @@ type (
 		Yaxes           []Axis           `json:"yaxes"` // was added in Grafana 4.x?
 		FieldConfig     *FieldConfig     `json:"fieldConfig,omitempty"`
 	}
+	OverRides struct {}
 	FieldConfig struct {
 		Defaults FieldConfigDefaults `json:"defaults"`
+		OverRides []OverRides `json:"overrides,omitempty"`
 	}
 	Options struct {
 		Orientation   string `json:"orientation"`
@@ -371,6 +373,7 @@ type (
 	TimeseriesTooltipOptions struct {
 		Mode string `json:"mode"`
 	}
+	Map struct {}
 	FieldConfigDefaults struct {
 		Unit       string            `json:"unit"`
 		Decimals   *int              `json:"decimals,omitempty"`
@@ -380,6 +383,7 @@ type (
 		Thresholds Thresholds        `json:"thresholds"`
 		Custom     FieldConfigCustom `json:"custom"`
 		Links      []Link            `json:"links,omitempty"`
+		Mappings   []Map             `json:"mappings,omitempty"`
 	}
 	FieldConfigCustom struct {
 		AxisLabel         string `json:"axisLabel,omitempty"`


### PR DESCRIPTION
Added 
  Empty datastructures mappings and overrides
  New Struct DataSource to match latest 8.x Grafana version

Unable to run go test 