### PR TITLE
Use SplitN to parse basic auth string, fixes #210

### DIFF
--- a/rest-request.go
+++ b/rest-request.go
@@ -69,7 +69,7 @@ func NewClient(apiURL, apiKeyOrBasicAuth string, client *http.Client) (*Client, 
 		if !basicAuth {
 			key = fmt.Sprintf("Bearer %s", apiKeyOrBasicAuth)
 		} else {
-			parts := strings.Split(apiKeyOrBasicAuth, ":")
+			parts := strings.SplitN(apiKeyOrBasicAuth, ":", 2)
 			baseURL.User = url.UserPassword(parts[0], parts[1])
 		}
 	}


### PR DESCRIPTION
Fixes the issue (#210) where if the basic auth string passed to `NewClient()` contains ":" in the password, the password is parsed out incorrectly:

**Code snippet:**
```
import (
	"fmt"

	"github.com/grafana-tools/sdk"
)

func main() {
	grafanaClient, _ := sdk.NewClient("http://grafana:3000", "admin"+":"+"pass:word", sdk.DefaultHTTPClient)
	fmt.Printf("%+v\n", grafanaClient)
}
```

**Before fix:**
```
&{baseURL:http://admin:pass@grafana:3000 key: basicAuth:true client:0x12b6820}
```

**After fix:**
```
&{baseURL:http://admin:pass%3Aword@grafana:3000 key: basicAuth:true client:0x12b6820}
```