### PR TITLE
Add panel_id field to Alert

### DIFF
--- a/panel.go
+++ b/panel.go
@@ -131,6 +131,7 @@ type (
 		Notifications       []AlertNotification `json:"notifications,omitempty"`
 		Message             string              `json:"message,omitempty"`
 		For                 string              `json:"for,omitempty"`
+    PanelID             *uint               `json:"panel_id,omitempty"`
 	}
 	GraphPanel struct {
 		AliasColors interface{} `json:"aliasColors"` // XXX

--- a/panel.go
+++ b/panel.go
@@ -131,7 +131,7 @@ type (
 		Notifications       []AlertNotification `json:"notifications,omitempty"`
 		Message             string              `json:"message,omitempty"`
 		For                 string              `json:"for,omitempty"`
-    PanelID             *uint               `json:"panel_id,omitempty"`
+    	PanelID             *uint               `json:"panel_id,omitempty"`
 	}
 	GraphPanel struct {
 		AliasColors interface{} `json:"aliasColors"` // XXX


### PR DESCRIPTION
When trying to create dashboards with alerts, Grafana returns
`HTTP error 422: returns alert validation error: Panel id is not correct...`

This is due to a validation found [here](https://github.com/grafana/grafana/blob/0124dc8e6b0fb6cd881bb51c98391f2efe203b78/pkg/models/alert.go#L93)

Adding this field so users can change the panel id of alerts.