### PR TITLE
Implement panel transformations

### DIFF
--- a/dashboard-unmarshal_test.go
+++ b/dashboard-unmarshal_test.go
@@ -225,3 +225,34 @@ func TestUnmarshal_DashboardWithGraphWithTargets83(t *testing.T) {
 	}
 
 }
+
+func TestUnmarshal_DashboardTableWithTransformations90(t *testing.T) {
+	var board sdk.Board
+
+	raw, err := ioutil.ReadFile("testdata/default-panels-table-with-transformations-9.0.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(raw, &board); err != nil {
+		t.Fatal(err)
+	}
+
+	panel := board.Panels[0]
+	if len(panel.CommonPanel.Transformations) != 1 {
+		t.Errorf("panel should have 1 transformation defined, but has %d", len(panel.CommonPanel.Transformations))
+	}
+
+	transform := panel.CommonPanel.Transformations[0]
+	if transform.ID != "histogram" {
+		t.Fatalf(`transformation ID should be "histogram", but got %s`, transform.ID)
+	}
+
+	options, ok := transform.Options.(map[string]interface{})
+	if !ok {
+		t.Fatalf("transformation options should be a map but got %T", transform.Options)
+	}
+
+	if options["bucketSize"] != 5.0 {
+		t.Fatalf("transformation bucket size should be 5.0, but got %+v", options["bucketSize"])
+	}
+}

--- a/panel.go
+++ b/panel.go
@@ -93,12 +93,13 @@ type (
 			Text     string `json:"text"`
 			Value    string `json:"value"`
 		} `json:"scopedVars,omitempty"`
-		Span        float32 `json:"span"`                  // general
-		Title       string  `json:"title"`                 // general
-		Description *string `json:"description,omitempty"` // general
-		Transparent bool    `json:"transparent"`
-		Type        string  `json:"type"`
-		Alert       *Alert  `json:"alert,omitempty"`
+		Span            float32          `json:"span"`                  // general
+		Title           string           `json:"title"`                 // general
+		Description     *string          `json:"description,omitempty"` // general
+		Transparent     bool             `json:"transparent"`
+		Type            string           `json:"type"`
+		Alert           *Alert           `json:"alert,omitempty"`
+		Transformations []Transformation `json:"transformations,omitempty"`
 	}
 	AlertEvaluator struct {
 		Params []float64 `json:"params,omitempty"`
@@ -429,7 +430,12 @@ type (
 		FixedColor string `json:"fixedColor,omitempty"`
 		SeriesBy   string `json:"seriesBy,omitempty"`
 	}
-	CustomPanel map[string]interface{}
+	CustomPanel    map[string]interface{}
+	Transformation struct {
+		ID       string      `json:"id"`
+		Disabled bool        `json:"disabled"`
+		Options  interface{} `json:"options"`
+	}
 )
 
 // for a graph panel

--- a/testdata/default-panels-table-with-transformations-9.0.json
+++ b/testdata/default-panels-table-with-transformations-9.0.json
@@ -1,0 +1,109 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "grafana"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto",
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "footer": {
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "9.0.3",
+      "title": "Panel Title",
+      "transformations": [
+        {
+          "id": "histogram",
+          "options": {
+            "bucketSize": 5,
+            "combine": true,
+            "fields": {}
+          }
+        }
+      ],
+      "type": "table"
+    }
+  ],
+  "schemaVersion": 36,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "New dashboard",
+  "version": 0,
+  "weekStart": ""
+}


### PR DESCRIPTION
Add support for panel transformations. I kept `options` field is an `interface{}`, because it is passed directly to the transformer and could theoretically be anything.